### PR TITLE
Multi-threaded implementation

### DIFF
--- a/pynndescent/threaded.py
+++ b/pynndescent/threaded.py
@@ -1,0 +1,534 @@
+import concurrent.futures
+import math
+import numba
+import numpy as np
+
+from pynndescent.utils import (
+    heap_push,
+    make_heap,
+    rejection_sample,
+    seed,
+    siftdown,
+    tau_rand,
+)
+
+# NNDescent algorithm
+
+INT32_MIN = np.iinfo(np.int32).min + 1
+INT32_MAX = np.iinfo(np.int32).max - 1
+
+
+def new_rng_state():
+    return np.random.randint(INT32_MIN, INT32_MAX, 3).astype(np.int64)
+
+
+def per_thread_rng_state(threads, rng_state):
+    """Create an array of per-thread RNG states, seeded from an initial rng_state."""
+    return rejection_sample(threads * 3, INT32_MAX, rng_state).reshape((threads, 3))
+
+
+@numba.njit("i8[:](i8, i8, i8)", nogil=True)
+def chunk_rows(chunk_size, index, n_vertices):
+    return np.arange(chunk_size * index, min(chunk_size * (index + 1), n_vertices))
+
+
+@numba.njit("f8[:, :](f8[:, :], i8)", nogil=True)
+def sort_heap_updates(heap_updates, num_heap_updates):
+    """Take an array of unsorted heap updates and sort by row number."""
+    row_numbers = heap_updates[:num_heap_updates, 0]
+    # use mergesort since it is stable (and supported by numba)
+    heap_updates[:num_heap_updates] = heap_updates[:num_heap_updates][
+        row_numbers.argsort(kind="mergesort")
+    ]
+    return heap_updates
+
+
+@numba.njit("i8[:](f8[:, :], i8, i8, i8)", nogil=True)
+def chunk_heap_updates(heap_updates, num_heap_updates, n_vertices, chunk_size):
+    """Return the offsets for each chunk of sorted heap updates."""
+    chunk_boundaries = (
+        np.arange(int(math.ceil(float(n_vertices) / chunk_size)) + 1) * chunk_size
+    )
+    offsets = np.searchsorted(
+        heap_updates[:num_heap_updates, 0], chunk_boundaries, side="left"
+    )
+    return offsets
+
+
+@numba.njit("void(f8[:, :, :], i8[:], i8[:, :], i8, i8, i8)", nogil=True)
+def shuffle_jit(
+    heap_updates, heap_update_counts, offsets, chunk_size, n_vertices, index
+):
+    sorted_heap_updates = sort_heap_updates(
+        heap_updates[index], heap_update_counts[index]
+    )
+    o = chunk_heap_updates(
+        sorted_heap_updates, heap_update_counts[index], n_vertices, chunk_size
+    )
+    offsets[index, : o.shape[0]] = o
+
+
+# Map Reduce functions to be jitted
+
+
+def make_current_graph_map_jit(dist, dist_args):
+    @numba.njit("i8(i8[:], i8, i8, f4[:, :], f8[:, :], i8[:], b1)", nogil=True)
+    def current_graph_map_jit(
+        rows, n_vertices, n_neighbors, data, heap_updates, rng_state, seed_per_row
+    ):
+        rng_state_local = rng_state.copy()
+        count = 0
+        for i in rows:
+            if seed_per_row:
+                seed(rng_state_local, i)
+            indices = rejection_sample(n_neighbors, n_vertices, rng_state_local)
+            for j in range(indices.shape[0]):
+                d = dist(data[i], data[indices[j]], *dist_args)
+                hu = heap_updates[count]
+                hu[0] = i
+                hu[1] = d
+                hu[2] = indices[j]
+                hu[3] = 1
+                count += 1
+                hu = heap_updates[count]
+                hu[0] = indices[j]
+                hu[1] = d
+                hu[2] = i
+                hu[3] = 1
+                count += 1
+        return count
+
+    return current_graph_map_jit
+
+
+@numba.njit("void(i8, f8[:, :, :], f8[:, :, :], i8[:, :], i8)", nogil=True)
+def current_graph_reduce_jit(n_tasks, current_graph, heap_updates, offsets, index):
+    for update_i in range(n_tasks):
+        o = offsets[update_i]
+        for j in range(o[index], o[index + 1]):
+            heap_update = heap_updates[update_i, j]
+            heap_push(
+                current_graph,
+                int(heap_update[0]),
+                heap_update[1],
+                int(heap_update[2]),
+                int(heap_update[3]),
+            )
+
+
+def init_current_graph(
+    data, dist, dist_args, n_neighbors, chunk_size, rng_state, threads=2, seed_per_row=False
+):
+
+    n_vertices = data.shape[0]
+    n_tasks = int(math.ceil(float(n_vertices) / chunk_size))
+
+    current_graph = make_heap(n_vertices, n_neighbors)
+
+    # store the updates in an array
+    max_heap_update_count = chunk_size * n_neighbors * 2
+    heap_updates = np.zeros((n_tasks, max_heap_update_count, 4))
+    heap_update_counts = np.zeros((n_tasks,), dtype=int)
+    rng_state_threads = per_thread_rng_state(n_tasks, rng_state)
+
+    current_graph_map_jit = make_current_graph_map_jit(dist, dist_args)
+
+    def current_graph_map(index):
+        rows = chunk_rows(chunk_size, index, n_vertices)
+        return (
+            index,
+            current_graph_map_jit(
+                rows, n_vertices, n_neighbors, data, heap_updates[index], rng_state_threads[index], seed_per_row=seed_per_row
+            ),
+        )
+
+    def current_graph_reduce(index):
+        return current_graph_reduce_jit(
+            n_tasks, current_graph, heap_updates, offsets, index
+        )
+
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=threads)
+    # run map functions
+    for index, count in executor.map(current_graph_map, range(n_tasks)):
+        heap_update_counts[index] = count
+
+    # sort and chunk heap updates so they can be applied in the reduce
+    max_count = heap_update_counts.max()
+    offsets = np.zeros((n_tasks, max_count), dtype=int)
+
+    def shuffle(index):
+        return shuffle_jit(
+            heap_updates, heap_update_counts, offsets, chunk_size, n_vertices, index
+        )
+
+    for _ in executor.map(shuffle, range(n_tasks)):
+        pass
+
+    # then run reduce functions
+    for _ in executor.map(current_graph_reduce, range(n_tasks)):
+        pass
+
+    return current_graph
+
+
+@numba.njit("i8(i8[:], i8, f8[:, :, :], f8[:, :], i8, f8, i8[:], b1)", nogil=True)
+def candidates_map_jit(
+    rows, n_neighbors, current_graph, heap_updates, offset, rho, rng_state, seed_per_row
+):
+    rng_state_local = rng_state.copy()
+    count = 0
+    for i in rows:
+        if seed_per_row:
+            seed(rng_state_local, i)
+        for j in range(n_neighbors):
+            if current_graph[0, i - offset, j] < 0:
+                continue
+            idx = current_graph[0, i - offset, j]
+            isn = current_graph[2, i - offset, j]
+            d = tau_rand(rng_state_local)
+            if tau_rand(rng_state_local) < rho:
+                # updates are common to old and new - decided by 'isn' flag
+                hu = heap_updates[count]
+                hu[0] = i
+                hu[1] = d
+                hu[2] = idx
+                hu[3] = isn
+                hu[4] = j
+                count += 1
+                hu = heap_updates[count]
+                hu[0] = idx
+                hu[1] = d
+                hu[2] = i
+                hu[3] = isn
+                hu[4] = -j - 1  # means i is at index 2
+                count += 1
+    return count
+
+
+@numba.njit(
+    "void(i8, f8[:, :, :], f8[:, :, :], f8[:, :, :], f8[:, :, :], i8[:, :], i8)",
+    nogil=True,
+)
+def candidates_reduce_jit(
+    n_tasks,
+    current_graph,
+    new_candidate_neighbors,
+    old_candidate_neighbors,
+    heap_updates,
+    offsets,
+    index,
+):
+    for update_i in range(n_tasks):
+        o = offsets[update_i]
+        for j in range(o[index], o[index + 1]):
+            heap_update = heap_updates[update_i, j]
+            if heap_update[3]:
+                c = heap_push(
+                    new_candidate_neighbors,
+                    int(heap_update[0]),
+                    heap_update[1],
+                    int(heap_update[2]),
+                    int(heap_update[3]),
+                )
+                if c > 0:
+                    k = int(heap_update[4])
+                    if k >= 0:
+                        i = int(heap_update[0])
+                    else:
+                        i = int(heap_update[2])
+                        k = -k - 1
+                    current_graph[2, i, k] = 0
+            else:
+                heap_push(
+                    old_candidate_neighbors,
+                    int(heap_update[0]),
+                    heap_update[1],
+                    int(heap_update[2]),
+                    int(heap_update[3]),
+                )
+
+
+def build_candidates(
+    current_graph,
+    n_vertices,
+    n_neighbors,
+    max_candidates,
+    chunk_size,
+    rng_state,
+    rho=0.5,
+    threads=2,
+    seed_per_row=False
+):
+
+    n_tasks = int(math.ceil(float(n_vertices) / chunk_size))
+
+    new_candidate_neighbors = make_heap(n_vertices, max_candidates)
+    old_candidate_neighbors = make_heap(n_vertices, max_candidates)
+
+    # store the updates in an array
+    max_heap_update_count = chunk_size * n_neighbors * 2
+    heap_updates = np.zeros((n_tasks, max_heap_update_count, 5))
+    heap_update_counts = np.zeros((n_tasks,), dtype=int)
+    rng_state_threads = per_thread_rng_state(n_tasks, rng_state)
+
+    def candidates_map(index):
+        rows = chunk_rows(chunk_size, index, n_vertices)
+        return (
+            index,
+            candidates_map_jit(
+                rows,
+                n_neighbors,
+                current_graph,
+                heap_updates[index],
+                offset=0,
+                rho=rho,
+                rng_state=rng_state_threads[index],
+                seed_per_row=seed_per_row
+            ),
+        )
+
+    def candidates_reduce(index):
+        return candidates_reduce_jit(
+            n_tasks,
+            current_graph,
+            new_candidate_neighbors,
+            old_candidate_neighbors,
+            heap_updates,
+            offsets,
+            index,
+        )
+
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=threads)
+    # run map functions
+    for index, count in executor.map(candidates_map, range(n_tasks)):
+        heap_update_counts[index] = count
+
+    # sort and chunk heap updates so they can be applied in the reduce
+    max_count = heap_update_counts.max()
+    offsets = np.zeros((n_tasks, max_count), dtype=int)
+
+    def shuffle(index):
+        return shuffle_jit(
+            heap_updates, heap_update_counts, offsets, chunk_size, n_vertices, index
+        )
+
+    for _ in executor.map(shuffle, range(n_tasks)):
+        pass
+
+    # then run reduce functions
+    for _ in executor.map(candidates_reduce, range(n_tasks)):
+        pass
+
+    return new_candidate_neighbors, old_candidate_neighbors
+
+
+def make_nn_descent_map_jit(dist, dist_args):
+    @numba.njit(
+        "i8(i8[:], i8, f4[:, :], f8[:, :, :], f8[:, :, :], f8[:, :], i8)",
+        nogil=True,
+        fastmath=True,
+    )
+    def nn_descent_map_jit(
+        rows,
+        max_candidates,
+        data,
+        new_candidate_neighbors,
+        old_candidate_neighbors,
+        heap_updates,
+        offset,
+    ):
+        count = 0
+        for i in rows:
+            i -= offset
+            for j in range(max_candidates):
+                p = int(new_candidate_neighbors[0, i, j])
+                if p < 0:
+                    continue
+                for k in range(j, max_candidates):
+                    q = int(new_candidate_neighbors[0, i, k])
+                    if q < 0:
+                        continue
+
+                    d = dist(data[p], data[q], *dist_args)
+                    hu = heap_updates[count]
+                    hu[0] = p
+                    hu[1] = d
+                    hu[2] = q
+                    hu[3] = 1
+                    count += 1
+                    hu = heap_updates[count]
+                    hu[0] = q
+                    hu[1] = d
+                    hu[2] = p
+                    hu[3] = 1
+                    count += 1
+
+                for k in range(max_candidates):
+                    q = int(old_candidate_neighbors[0, i, k])
+                    if q < 0:
+                        continue
+
+                    d = dist(data[p], data[q], *dist_args)
+                    hu = heap_updates[count]
+                    hu[0] = p
+                    hu[1] = d
+                    hu[2] = q
+                    hu[3] = 1
+                    count += 1
+                    hu = heap_updates[count]
+                    hu[0] = q
+                    hu[1] = d
+                    hu[2] = p
+                    hu[3] = 1
+                    count += 1
+        return count
+
+    return nn_descent_map_jit
+
+
+@numba.njit("i8(i8, f8[:, :, :], f8[:, :, :], i8[:, :], i8)", nogil=True)
+def nn_decent_reduce_jit(n_tasks, current_graph, heap_updates, offsets, index):
+    c = 0
+    for update_i in range(n_tasks):
+        o = offsets[update_i]
+        for j in range(o[index], o[index + 1]):
+            heap_update = heap_updates[update_i, j]
+            c += heap_push(
+                current_graph,
+                heap_update[0],
+                heap_update[1],
+                heap_update[2],
+                heap_update[3],
+            )
+    return c
+
+
+@numba.njit("void(i8[:], f8[:, :, :])", nogil=True)
+def deheap_sort_map_jit(rows, heap):
+    indices = heap[0]
+    weights = heap[1]
+
+    for i in rows:
+
+        ind_heap = indices[i]
+        dist_heap = weights[i]
+
+        for j in range(ind_heap.shape[0] - 1):
+            ind_heap[0], ind_heap[ind_heap.shape[0] - j - 1] = \
+                ind_heap[ind_heap.shape[0] - j - 1], ind_heap[0]
+            dist_heap[0], dist_heap[dist_heap.shape[0] - j - 1] = \
+                dist_heap[dist_heap.shape[0] - j - 1], dist_heap[0]
+
+            siftdown(dist_heap[:dist_heap.shape[0] - j - 1],
+                     ind_heap[:ind_heap.shape[0] - j - 1], 0)
+
+
+def make_nn_descent(dist, dist_args):
+    def nn_descent(
+        data,
+        n_neighbors,
+        rng_state,
+        chunk_size,
+        max_candidates=50,
+        n_iters=10,
+        delta=0.001,
+        rho=0.5,
+        rp_tree_init=False,
+        leaf_array=None,
+        verbose=False,
+        threads=2,
+        seed_per_row=False
+    ):
+
+        if rng_state is None:
+            rng_state = new_rng_state()
+
+        n_vertices = data.shape[0]
+        n_tasks = int(math.ceil(float(n_vertices) / chunk_size))
+
+        current_graph = init_current_graph(
+            data, dist, dist_args, n_neighbors, chunk_size, rng_state, threads, seed_per_row=seed_per_row
+        )
+
+        # store the updates in an array
+        # note that the factor here is `n_neighbors * n_neighbors`, not `max_candidates * max_candidates`
+        # since no more than `n_neighbors` candidates are added for each row
+        max_heap_update_count = chunk_size * n_neighbors * n_neighbors * 4
+        heap_updates = np.zeros((n_tasks, max_heap_update_count, 4))
+        heap_update_counts = np.zeros((n_tasks,), dtype=int)
+
+        nn_descent_map_jit = make_nn_descent_map_jit(dist, dist_args)
+
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=threads)
+
+        for n in range(n_iters):
+            (new_candidate_neighbors, old_candidate_neighbors) = build_candidates(
+                current_graph,
+                n_vertices,
+                n_neighbors,
+                max_candidates,
+                chunk_size,
+                rng_state,
+                rho,
+                threads,
+                seed_per_row=seed_per_row
+            )
+
+            def nn_descent_map(index):
+                rows = chunk_rows(chunk_size, index, n_vertices)
+                return (
+                    index,
+                    nn_descent_map_jit(
+                        rows,
+                        max_candidates,
+                        data,
+                        new_candidate_neighbors,
+                        old_candidate_neighbors,
+                        heap_updates[index],
+                        offset=0,
+                    ),
+                )
+
+            def nn_decent_reduce(index):
+                return nn_decent_reduce_jit(
+                    n_tasks, current_graph, heap_updates, offsets, index
+                )
+
+            # run map functions
+            for index, count in executor.map(nn_descent_map, range(n_tasks)):
+                heap_update_counts[index] = count
+
+            # sort and chunk heap updates so they can be applied in the reduce
+            max_count = heap_update_counts.max()
+            offsets = np.zeros((n_tasks, max_count), dtype=int)
+
+            def shuffle(index):
+                return shuffle_jit(
+                    heap_updates,
+                    heap_update_counts,
+                    offsets,
+                    chunk_size,
+                    n_vertices,
+                    index,
+                )
+
+            for _ in executor.map(shuffle, range(n_tasks)):
+                pass
+
+            # then run reduce functions
+            c = 0
+            for c_part in executor.map(nn_decent_reduce, range(n_tasks)):
+                c += c_part
+
+            if c <= delta * n_neighbors * data.shape[0]:
+                break
+
+        def deheap_sort_map(index):
+            rows = chunk_rows(chunk_size, index, n_vertices)
+            return index, deheap_sort_map_jit(rows, current_graph)
+
+        for _ in executor.map(deheap_sort_map, range(n_tasks)):
+            pass
+        return current_graph[0].astype(np.int64), current_graph[1]
+
+    return nn_descent

--- a/test_threaded.py
+++ b/test_threaded.py
@@ -96,13 +96,14 @@ def test_nn_descent():
         seed_per_row=True
     )
 
-    nn_descent_threaded = threaded.make_nn_descent(dist, dist_args)
-    nn_indices_threaded, nn_distances_threaded = nn_descent_threaded(
+    nn_indices_threaded, nn_distances_threaded = threaded.nn_descent(
         data,
         n_neighbors=n_neighbors,
         rng_state=new_rng_state(),
         chunk_size=chunk_size,
         max_candidates=max_candidates,
+        dist=dist,
+        dist_args=dist_args,
         n_iters=2,
         delta=0,
         rp_tree_init=False,

--- a/test_threaded.py
+++ b/test_threaded.py
@@ -1,0 +1,162 @@
+import numpy as np
+
+from numpy.testing import assert_allclose
+
+from sklearn.neighbors import NearestNeighbors
+
+from pynndescent import distances
+from pynndescent import pynndescent_
+from pynndescent import threaded
+from pynndescent import utils
+
+data = np.array(
+    [[-1, -1], [-2, -1], [-3, -2], [1, 1], [2, 1], [3, 2]], dtype=np.float32
+)
+chunk_size = 4
+n_neighbors = 2
+max_candidates = 8
+
+dist = distances.named_distances["euclidean"]
+dist_args = ()
+
+# np.random.seed(42)
+#
+# N = 100000
+# D = 128
+# dataset = np.random.rand(N, D).astype(np.float32)
+#
+# chunk_size = 4000//8
+# n_neighbors = 25
+# max_candidates = 50
+#
+# data = dataset[:4000].astype(np.float32)
+
+# In all tests, set seed_per_row=True so that we can comapre the regular
+# algorithm against the threded algorithm.
+
+def new_rng_state():
+    return np.empty((3,), dtype=np.int64)
+
+
+def accuracy(expected, actual):
+    # Look at the size of corresponding row intersections
+    return np.array([len(np.intersect1d(x, y)) for x, y in zip(expected, actual)]).sum() / expected.size
+
+
+def test_init_current_graph():
+    current_graph = pynndescent_.init_current_graph(data, dist, dist_args, n_neighbors, rng_state=new_rng_state(), seed_per_row=True)
+    current_graph_threaded = threaded.init_current_graph(
+        data, dist, dist_args, n_neighbors, chunk_size=chunk_size, rng_state=new_rng_state(),
+        seed_per_row=True
+    )
+
+    assert_allclose(current_graph_threaded, current_graph)
+
+
+def test_build_candidates():
+    n_vertices = data.shape[0]
+
+    current_graph = pynndescent_.init_current_graph(data, dist, dist_args, n_neighbors, rng_state=new_rng_state(), seed_per_row=True)
+    new_candidate_neighbors, old_candidate_neighbors = utils.build_candidates(
+        current_graph,
+        n_vertices,
+        n_neighbors,
+        max_candidates,
+        rng_state=new_rng_state(),
+        seed_per_row=True
+    )
+
+    current_graph = pynndescent_.init_current_graph(data, dist, dist_args, n_neighbors, rng_state=new_rng_state(), seed_per_row=True)
+    new_candidate_neighbors_threaded, old_candidate_neighbors_threaded = threaded.build_candidates(
+        current_graph,
+        n_vertices,
+        n_neighbors,
+        max_candidates,
+        chunk_size=chunk_size,
+        rng_state=new_rng_state(),
+        seed_per_row=True
+    )
+
+    assert_allclose(new_candidate_neighbors_threaded, new_candidate_neighbors)
+    assert_allclose(old_candidate_neighbors_threaded, old_candidate_neighbors)
+
+
+def test_nn_descent():
+    nn_indices, nn_distances = pynndescent_.nn_descent(
+        data,
+        n_neighbors=n_neighbors,
+        rng_state=new_rng_state(),
+        max_candidates=max_candidates,
+        dist=dist,
+        dist_args=dist_args,
+        n_iters=2,
+        delta=0,
+        rp_tree_init=False,
+        leaf_array=np.array([[-1]]),
+        seed_per_row=True
+    )
+
+    nn_descent_threaded = threaded.make_nn_descent(dist, dist_args)
+    nn_indices_threaded, nn_distances_threaded = nn_descent_threaded(
+        data,
+        n_neighbors=n_neighbors,
+        rng_state=new_rng_state(),
+        chunk_size=chunk_size,
+        max_candidates=max_candidates,
+        n_iters=2,
+        delta=0,
+        rp_tree_init=False,
+        seed_per_row=True
+    )
+
+    nbrs = NearestNeighbors(n_neighbors=n_neighbors, algorithm='brute').fit(data)
+    _, nn_gold_indices = nbrs.kneighbors(data)
+
+    print("regular accuracy", accuracy(nn_gold_indices, nn_indices))
+    print("threaded accuracy", accuracy(nn_gold_indices, nn_indices_threaded))
+
+    assert_allclose(nn_indices_threaded, nn_indices)
+    assert_allclose(nn_distances_threaded, nn_distances)
+
+
+def test_heap_updates():
+    heap_updates = np.array(
+        [
+            [4, 1, 15, 0],
+            [3, 3, 12, 0],
+            [2, 2, 14, 0],
+            [1, 5, 29, 0],
+            [4, 7, 40, 0],
+            [0, 0, 0, 0],
+        ],
+        dtype=np.float64,
+    )
+    num_heap_updates = 5
+    chunk_size = 2
+    threaded.sort_heap_updates(heap_updates, num_heap_updates)
+
+    sorted_heap_updates = np.array(
+        [
+            [1, 5, 29, 0],
+            [2, 2, 14, 0],
+            [3, 3, 12, 0],
+            [4, 1, 15, 0],
+            [4, 7, 40, 0],
+            [0, 0, 0, 0],
+        ],
+        dtype=np.float64,
+    )
+    assert_allclose(heap_updates, sorted_heap_updates)
+
+    offsets = threaded.chunk_heap_updates(sorted_heap_updates, num_heap_updates, 6, chunk_size)
+
+    assert_allclose(offsets, np.array([0, 1, 3, 5]))
+
+    chunk0 = sorted_heap_updates[offsets[0] : offsets[1]]
+    assert_allclose(chunk0, np.array([[1, 5, 29, 0]]))
+
+    chunk1 = sorted_heap_updates[offsets[1] : offsets[2]]
+    assert_allclose(chunk1, np.array([[2, 2, 14, 0], [3, 3, 12, 0]]))
+
+    chunk2 = sorted_heap_updates[offsets[2] : offsets[3]]
+    assert_allclose(chunk2, np.array([[4, 1, 15, 0], [4, 7, 40, 0]]))

--- a/test_threaded.py
+++ b/test_threaded.py
@@ -6,6 +6,7 @@ from sklearn.neighbors import NearestNeighbors
 
 from pynndescent import distances
 from pynndescent import pynndescent_
+from pynndescent import NNDescent
 from pynndescent import threaded
 from pynndescent import utils
 
@@ -82,33 +83,27 @@ def test_build_candidates():
 
 
 def test_nn_descent():
-    nn_indices, nn_distances = pynndescent_.nn_descent(
+    nn_indices, nn_distances = NNDescent(
         data,
         n_neighbors=n_neighbors,
-        rng_state=new_rng_state(),
         max_candidates=max_candidates,
-        dist=dist,
-        dist_args=dist_args,
         n_iters=2,
         delta=0,
-        rp_tree_init=False,
-        leaf_array=np.array([[-1]]),
+        tree_init=False,
         seed_per_row=True
-    )
+    )._neighbor_graph
 
-    nn_indices_threaded, nn_distances_threaded = threaded.nn_descent(
+    nn_indices_threaded, nn_distances_threaded = NNDescent(
         data,
         n_neighbors=n_neighbors,
-        rng_state=new_rng_state(),
-        chunk_size=chunk_size,
         max_candidates=max_candidates,
-        dist=dist,
-        dist_args=dist_args,
         n_iters=2,
         delta=0,
-        rp_tree_init=False,
-        seed_per_row=True
-    )
+        tree_init=False,
+        seed_per_row=True,
+        algorithm='threaded',
+        chunk_size=chunk_size
+    )._neighbor_graph
 
     nbrs = NearestNeighbors(n_neighbors=n_neighbors, algorithm='brute').fit(data)
     _, nn_gold_indices = nbrs.kneighbors(data)


### PR DESCRIPTION
Currently, pynndescent doesn't take full advantage of multiple cores on a machine. There are some methods annotated with the Numba [parallel](http://numba.pydata.org/numba-doc/latest/user/parallel.html) option, but these don't provide any noticeable speed up when more cores are available.

This PR allows nearest neighbor computation to take advantage of multiple cores by processing heaps in parallel chunks. The basic idea is an application of the MapReduce approach described in section 2.8 of [Efficient K-Nearest Neighbor Graph Construction for Generic Similarity Measures](http://www.cs.princeton.edu/cass/papers/www11.pdf) by Dong et al.

Note that in this PR all computation is carried out on a single machine using the standard Python [concurrent.futures](https://docs.python.org/3/library/concurrent.futures.html) library, which complements Numba very well, as shown in [this example](https://numba.pydata.org/numba-doc/dev/user/examples.html#multi-threading).

Going into slightly more detail, a distributed heap can be updated in a MapReduce-style operation as follows.

We have a large array of all the heap updates held in memory and a thread pool to update chunks in parallel in two phases, called "Map" and "Reduce". Each Map partition holds an array of heap updates, corresponding to a row in the following diagram.

![heap_updates](https://user-images.githubusercontent.com/85085/53956465-9561c300-40d3-11e9-822f-d533e8aaccf9.png)

The Map phase adds updates in the order they were generated (from `heap_push` calls). After all the updates have been added for a partition, the updates for that partition are sorted by row number. Then the chunk boundaries corresponding to partitions are found, so that in the Reduce phase the array can process all the updates for a given partition together, and apply them to the target heap (not illustrated).

For the Map phase the array is processed row-wise, and in the Reduce phase it is processed column-wise (although the column bounds are different for each row owing to the different chunk boundaries). The result is an updated distributed heap.

This PR also adds tests that check the threaded implementation produces the same result as the regular implementation. Since NN-Descent uses a source of randomness, when running the tests the random seed is set to the value of each row index to ensure the same deterministic result is obtained. This per-row seeding is only used for tests. However, to make threaded runs more reproducible when run normally (outside of tests) each thread is seeded from the initial random seed, which means that the result from two threaded runs (with the same number of threads) is the same if the same initial seed is used in each case.

In terms of performance, the multi-threaded implementation outperforms the regular implementation with 4 cores or more. In one experiment, regular pynndescent took 27 minutes for a million rows (D=128, NN=25), compared to just over 3 minutes with 64 threads.

There is more work to consider how to wire up the implementation to the standard NNDescent object, but I wanted to get feedback on this approach before going any further.