### PR TITLE
Windows CI with Appveyor

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,9 @@
 .. image:: https://travis-ci.org/lmcinnes/pynndescent.svg
     :target: https://travis-ci.org/lmcinnes/pynndescent
     :alt: Travis Build Status
+.. image:: https://ci.appveyor.com/api/projects/status/github/lmcinnes/pynndescent?branch=master&svg=true
+    :target: https://ci.appveyor.com/project/lmcinnes/pynndescent
+    :alt: AppVeyor Build Status
 ===========
 PyNNDescent
 ===========

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - "conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy numba nose"
+  - "conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy sklearn numba nose"
   - activate test-environment
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - "conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy sklearn numba nose"
+  - "conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy scikit-learn numba nose"
   - activate test-environment
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,23 @@
+build: "off"
+
+environment:
+  matrix:
+    - PYTHON_VERSION: "3.6"
+      MINICONDA: C:\Miniconda36-x64
+    - PYTHON_VERSION: "3.7"
+      MINICONDA: C:\Miniconda3-x64
+
+init:
+  - "ECHO %PYTHON_VERSION% %MINICONDA%"
+
+install:
+  - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - conda info -a
+  - "conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy nose"
+  - activate test-environment
+
+test_script:
+  - nosetests
+  

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - "conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy nose"
+  - "conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy numba nose"
   - activate test-environment
 
 test_script:


### PR DESCRIPTION
Good news: this PR introduces CI on Windows.
Bad news: tests are failing.
Ok news:  it seems reproducible on my machine, so I can probably start fixing it.

@lmcinnes: you will need to click on the badge and then activate the repo on Appveyor to start this going. If you don't have an account you can give it access via github, similarly to travis-ci. Speaking of which, the travis ci also needs to be activated by the same method (click its badge and so on).