### PR TITLE
backport UMAP 0.4dev changes

### DIFF
--- a/pynndescent/pynndescent_.py
+++ b/pynndescent/pynndescent_.py
@@ -80,7 +80,7 @@ def initialise_search(
 
 
 def make_initialized_nnd_search(dist, dist_args):
-    @numba.njit(parallel=True)
+    @numba.njit(parallel=True, fastmath=True)
     def initialized_nnd_search(data, indptr, indices, initialization, query_points):
 
         for i in numba.prange(query_points.shape[0]):

--- a/pynndescent/pynndescent_.py
+++ b/pynndescent/pynndescent_.py
@@ -126,22 +126,27 @@ def init_current_graph(
 
 
 @numba.njit(fastmath=True)
-def init_rp_tree(data, dist, dist_args, current_graph, leaf_array):
-    for n in range(leaf_array.shape[0]):
+def init_rp_tree(data, dist, dist_args, current_graph, leaf_array, tried=None):
+    if tried is None:
         tried = set([(-1, -1)])
+
+    for n in range(leaf_array.shape[0]):
         for i in range(leaf_array.shape[1]):
-            if leaf_array[n, i] < 0:
+            p = leaf_array[n, i]
+            if p < 0:
                 break
             for j in range(i + 1, leaf_array.shape[1]):
-                if leaf_array[n, j] < 0:
+                q = leaf_array[n, j]
+                if q < 0:
                     break
-                if (leaf_array[n, i], leaf_array[n, j]) in tried:
+                if (p, q) in tried:
                     continue
-                d = dist(data[leaf_array[n, i]], data[leaf_array[n, j]], *dist_args)
-                heap_push(current_graph, leaf_array[n, i], d, leaf_array[n, j], 1)
-                heap_push(current_graph, leaf_array[n, j], d, leaf_array[n, i], 1)
-                tried.add((leaf_array[n, i], leaf_array[n, j]))
-                tried.add((leaf_array[n, j], leaf_array[n, i]))
+                d = dist(data[p], data[q], *dist_args)
+                heap_push(current_graph, p, d, q, 1)
+                tried.add((p, q))
+                if p != q:
+                    heap_push(current_graph, q, d, p, 1)
+                    tried.add((q, p))
 
 
 @numba.njit(fastmath=True)
@@ -176,23 +181,7 @@ def nn_descent(
             tried.add((indices[j], i))
 
     if rp_tree_init:
-        for n in range(leaf_array.shape[0]):
-            for i in range(leaf_array.shape[1]):
-                p = leaf_array[n, i]
-                if p < 0:
-                    break
-                for j in range(i + 1, leaf_array.shape[1]):
-                    q = leaf_array[n, j]
-                    if q < 0:
-                        break
-                    if (p, q) in tried:
-                        continue
-                    d = dist(data[p], data[q], *dist_args)
-                    unchecked_heap_push(current_graph, p, d, q, 1)
-                    tried.add((p, q))
-                    if p != q:
-                        unchecked_heap_push(current_graph, q, d, p, 1)
-                        tried.add((q, p))
+        init_rp_tree(data, dist, dist_args, current_graph, leaf_array, tried=tried)
 
     for n in range(n_iters):
 

--- a/pynndescent/pynndescent_.py
+++ b/pynndescent/pynndescent_.py
@@ -33,7 +33,7 @@ INT32_MAX = np.iinfo(np.int32).max - 1
 
 
 def make_initialisations(dist, dist_args):
-    @numba.njit(parallel=True)
+    @numba.njit(parallel=True, fastmath=True)
     def init_from_random(n_neighbors, data, query_points, heap, rng_state):
         for i in range(query_points.shape[0]):
             indices = rejection_sample(n_neighbors, data.shape[0], rng_state)
@@ -44,7 +44,7 @@ def make_initialisations(dist, dist_args):
                 heap_push(heap, i, d, indices[j], 1)
         return
 
-    @numba.njit(parallel=True)
+    @numba.njit(parallel=True, fastmath=True)
     def init_from_tree(tree, data, query_points, heap, rng_state):
         for i in range(query_points.shape[0]):
             indices = search_flat_tree(
@@ -145,7 +145,7 @@ def init_rp_tree(data, dist, dist_args, current_graph, leaf_array):
                 tried.add((leaf_array[n, j], leaf_array[n, i]))
 
 
-@numba.njit()
+@numba.njit(fastmath=True)
 def nn_descent(
     data,
     n_neighbors,

--- a/pynndescent/pynndescent_.py
+++ b/pynndescent/pynndescent_.py
@@ -14,6 +14,7 @@ import pynndescent.sparse as sparse
 import pynndescent.threaded as threaded
 
 from pynndescent.utils import (
+    tau_rand,
     rejection_sample,
     seed,
     make_heap,
@@ -32,7 +33,7 @@ INT32_MAX = np.iinfo(np.int32).max - 1
 
 
 def make_initialisations(dist, dist_args):
-    @numba.njit(parallel=True, fastmath=True)
+    @numba.njit(parallel=True)
     def init_from_random(n_neighbors, data, query_points, heap, rng_state):
         for i in range(query_points.shape[0]):
             indices = rejection_sample(n_neighbors, data.shape[0], rng_state)
@@ -43,7 +44,7 @@ def make_initialisations(dist, dist_args):
                 heap_push(heap, i, d, indices[j], 1)
         return
 
-    @numba.njit(parallel=True, fastmath=True)
+    @numba.njit(parallel=True)
     def init_from_tree(tree, data, query_points, heap, rng_state):
         for i in range(query_points.shape[0]):
             indices = search_flat_tree(
@@ -79,7 +80,7 @@ def initialise_search(
 
 
 def make_initialized_nnd_search(dist, dist_args):
-    @numba.njit(parallel=True, fastmath=True)
+    @numba.njit(parallel=True)
     def initialized_nnd_search(data, indptr, indices, initialization, query_points):
 
         for i in numba.prange(query_points.shape[0]):
@@ -144,7 +145,7 @@ def init_rp_tree(data, dist, dist_args, current_graph, leaf_array):
                 tried.add((leaf_array[n, j], leaf_array[n, i]))
 
 
-@numba.njit(fastmath=True)
+@numba.njit()
 def nn_descent(
     data,
     n_neighbors,
@@ -161,6 +162,7 @@ def nn_descent(
     seed_per_row=False,
 ):
     n_vertices = data.shape[0]
+    tried = set([(-1, -1)])
 
     current_graph = make_heap(data.shape[0], n_neighbors)
     for i in range(data.shape[0]):
@@ -171,9 +173,28 @@ def nn_descent(
             d = dist(data[i], data[indices[j]], *dist_args)
             heap_push(current_graph, i, d, indices[j], 1)
             heap_push(current_graph, indices[j], d, i, 1)
+            tried.add((i, indices[j]))
+            tried.add((indices[j], i))
 
     if rp_tree_init:
-        init_rp_tree(data, dist, dist_args, current_graph, leaf_array)
+        for n in range(leaf_array.shape[0]):
+            for i in range(leaf_array.shape[1]):
+                if leaf_array[n, i] < 0:
+                    break
+                for j in range(i + 1, leaf_array.shape[1]):
+                    if leaf_array[n, j] < 0:
+                        break
+                    if (leaf_array[n, i], leaf_array[n, j]) in tried:
+                        continue
+                    d = dist(data[leaf_array[n, i]], data[leaf_array[n, j]], *dist_args)
+                    unchecked_heap_push(
+                        current_graph, leaf_array[n, i], d, leaf_array[n, j], 1
+                    )
+                    unchecked_heap_push(
+                        current_graph, leaf_array[n, j], d, leaf_array[n, i], 1
+                    )
+                    tried.add((leaf_array[n, i], leaf_array[n, j]))
+                    tried.add((leaf_array[n, j], leaf_array[n, i]))
 
     for n in range(n_iters):
 
@@ -195,21 +216,27 @@ def nn_descent(
                     continue
                 for k in range(j, max_candidates):
                     q = int(new_candidate_neighbors[0, i, k])
-                    if q < 0:
+                    if q < 0 or (p, q) in tried:
                         continue
 
                     d = dist(data[p], data[q], *dist_args)
+                    # c += unchecked_heap_push(current_graph, p, d, q, 1)
+                    # c += unchecked_heap_push(current_graph, q, d, p, 1)
                     c += heap_push(current_graph, p, d, q, 1)
                     c += heap_push(current_graph, q, d, p, 1)
+                    tried.add((p, q))
+                    tried.add((q, p))
 
                 for k in range(max_candidates):
                     q = int(old_candidate_neighbors[0, i, k])
-                    if q < 0:
+                    if q < 0 or (p, q) in tried:
                         continue
 
                     d = dist(data[p], data[q], *dist_args)
-                    c += heap_push(current_graph, p, d, q, 1)
-                    c += heap_push(current_graph, q, d, p, 1)
+                    c += unchecked_heap_push(current_graph, p, d, q, 1)
+                    c += unchecked_heap_push(current_graph, q, d, p, 1)
+                    tried.add((p, q))
+                    tried.add((q, p))
 
         if c <= delta * n_neighbors * data.shape[0]:
             break

--- a/pynndescent/rp_trees.py
+++ b/pynndescent/rp_trees.py
@@ -129,7 +129,7 @@ def angular_random_projection_split(data, indices, rng_state):
     return indices_left, indices_right, hyperplane_vector, None
 
 
-@numba.njit(fastmath=True)
+@numba.njit(fastmath=True, nogil=True, parallel=True)
 def euclidean_random_projection_split(data, indices, rng_state):
     """Given a set of ``indices`` for data points from ``data``, create
     a random hyperplane to split the data, returning two arrays indices
@@ -441,7 +441,6 @@ def sparse_euclidean_random_projection_split(inds, indptr, data, indices, rng_st
     return indices_left, indices_right, hyperplane, hyperplane_offset
 
 
-@numba.jit()
 def make_euclidean_tree(data, indices, rng_state, leaf_size=30):
     if indices.shape[0] > leaf_size:
         left_indices, right_indices, hyperplane, offset = euclidean_random_projection_split(
@@ -460,7 +459,6 @@ def make_euclidean_tree(data, indices, rng_state, leaf_size=30):
     return node
 
 
-@numba.jit()
 def make_angular_tree(data, indices, rng_state, leaf_size=30):
     if indices.shape[0] > leaf_size:
         left_indices, right_indices, hyperplane, offset = angular_random_projection_split(
@@ -479,7 +477,6 @@ def make_angular_tree(data, indices, rng_state, leaf_size=30):
     return node
 
 
-@numba.jit()
 def make_sparse_euclidean_tree(inds, indptr, data, indices, rng_state, leaf_size=30):
     if indices.shape[0] > leaf_size:
         left_indices, right_indices, hyperplane, offset = sparse_euclidean_random_projection_split(
@@ -502,7 +499,6 @@ def make_sparse_euclidean_tree(inds, indptr, data, indices, rng_state, leaf_size
     return node
 
 
-@numba.jit()
 def make_sparse_angular_tree(inds, indptr, data, indices, rng_state, leaf_size=30):
     if indices.shape[0] > leaf_size:
         left_indices, right_indices, hyperplane, offset = sparse_angular_random_projection_split(
@@ -753,7 +749,7 @@ def make_forest(data, n_neighbors, n_trees, rng_state, angular=False):
             flatten_tree(make_tree(data, rng_state, leaf_size, angular), leaf_size)
             for i in range(n_trees)
         ]
-    except (RuntimeError, RecursionError):
+    except (RuntimeError, RecursionError, SystemError):
         warn(
             "Random Projection forest initialisation failed due to recursion"
             "limit being reached. Something is a little strange with your "

--- a/pynndescent/tests/test_pynndescent_.py
+++ b/pynndescent/tests/test_pynndescent_.py
@@ -141,6 +141,13 @@ def test_rp_trees_should_not_stack_overflow_with_duplicate_data():
         data, "cosine", {}, n_neighbors, random_state=np.random, n_trees=20
     )._neighbor_graph
 
+    for i in range(data.shape[0]):
+        assert_equals(
+            len(knn_indices[i]),
+            len(np.unique(knn_indices[i])),
+            "Duplicate indices in knn graph",
+        )
+
     angular_data = normalize(data, norm="l2")
     tree = KDTree(angular_data)
     true_indices = tree.query(angular_data, n_neighbors, return_distance=False)

--- a/pynndescent/tests/test_threaded.py
+++ b/pynndescent/tests/test_threaded.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from numpy.testing import assert_allclose
+from nose.tools import assert_equals
 
 from sklearn.neighbors import NearestNeighbors
 
@@ -135,6 +136,13 @@ def test_nn_descent():
         seed_per_row=True,
     )._neighbor_graph
 
+    for i in range(data.shape[0]):
+        assert_equals(
+            len(nn_indices[i]),
+            len(np.unique(nn_indices[i])),
+            "Duplicate indices in unthreaded knn graph",
+        )
+
     nn_indices_threaded, nn_distances_threaded = NNDescent(
         data,
         n_neighbors=n_neighbors,
@@ -146,6 +154,13 @@ def test_nn_descent():
         algorithm="threaded",
         chunk_size=chunk_size,
     )._neighbor_graph
+
+    for i in range(data.shape[0]):
+        assert_equals(
+            len(nn_indices_threaded[i]),
+            len(np.unique(nn_indices_threaded[i])),
+            "Duplicate indices in threaded knn graph",
+        )
 
     nbrs = NearestNeighbors(n_neighbors=n_neighbors, algorithm="brute").fit(data)
     _, nn_gold_indices = nbrs.kneighbors(data)

--- a/pynndescent/utils.py
+++ b/pynndescent/utils.py
@@ -57,7 +57,7 @@ def tau_rand(state):
     return abs(float(integer) / 0x7FFFFFFF)
 
 
-@numba.njit()
+@numba.njit(fastmath=True)
 def norm(vec):
     """Compute the (standard l2) norm of a vector.
 
@@ -75,7 +75,7 @@ def norm(vec):
     return np.sqrt(result)
 
 
-@numba.njit()
+@numba.njit(parallel=True)
 def rejection_sample(n_samples, pool_size, rng_state):
     """Generate n_samples many integers from 0 to pool_size such that no
     integer is selected twice. The duplication constraint is achieved via
@@ -464,7 +464,7 @@ def new_build_candidates(
     rng_state,
     rho=0.5,
     seed_per_row=False,
-):  # pragma: no cover
+):
     """Build a heap of candidate neighbors for nearest neighbor descent. For
     each vertex the candidate neighbors are any current neighbors, and any
     vertices that have the vertex as one of their nearest neighbors.
@@ -494,7 +494,6 @@ def new_build_candidates(
     new_candidate_neighbors = make_heap(n_vertices, max_candidates)
     old_candidate_neighbors = make_heap(n_vertices, max_candidates)
 
-    #    for i in numba.prange(n_vertices):
     for i in range(n_vertices):
         if seed_per_row:
             seed(rng_state, i)


### PR DESCRIPTION
Relates to https://github.com/lmcinnes/pynndescent/issues/37

This isn't intended to be merged in its current state, this is just to conveniently show the current state of the diffs. The things to look at are:

* numba decorations. Sometimes UMAP has more, sometimes it's vice versa. I don't know which ones are necessary or helpful.
* In `new_build_candidates`, there is a test failure when using `numba.prange`, so I have commented it out and used  a plain old `range`.
* The biggest change is to the nearest neighbor descent routine, which introduces a set to keep track of previously seen pairs, and unchecked heap pushes. There are two test failures due to a much lower expected accuracy, unless I comment out the use of the unchecked heap push in the first loop in the nn descent iteration. Not tracked down the problem there yet.
* In general for nn descent, is it safe to use a set to cache the lookups? It seems like it could grow to be O(N^2) in the worst case? I think something like this is mentioned in the nn descent paper.
* In UMAP 0.4, the search initialization is handled slightly differently, in that each function is separate and `dist` and `dist_args` have to be provided to `init_from_tree` and its ilk directly, whereas in pynndescent, `dist` and `dist_args` are passed to a factory function and the initialization functions access them via closure. Which is the preferred way to do things?