### PR TITLE
Sample only the reversed neighbour

### DIFF
--- a/pynndescent/utils.py
+++ b/pynndescent/utils.py
@@ -503,17 +503,21 @@ def new_build_candidates(
             idx = current_graph[0, i, j]
             isn = current_graph[2, i, j]
             d = tau_rand(rng_state)
+            c = 0
+
+            if isn:
+                c += heap_push(new_candidate_neighbors, i, d, idx, isn)
+            else:
+                heap_push(old_candidate_neighbors, i, d, idx, isn)
+
             if tau_rand(rng_state) < rho:
-                c = 0
                 if isn:
-                    c += heap_push(new_candidate_neighbors, i, d, idx, isn)
                     c += heap_push(new_candidate_neighbors, idx, d, i, isn)
                 else:
-                    heap_push(old_candidate_neighbors, i, d, idx, isn)
                     heap_push(old_candidate_neighbors, idx, d, i, isn)
 
-                if c > 0:
-                    current_graph[2, i, j] = 0
+            if c > 0:
+                current_graph[2, i, j] = 0
 
     return new_candidate_neighbors, old_candidate_neighbors
 


### PR DESCRIPTION
Right now we sample both the neighbours and reversed neighbours. Following the paper, we only sample the reversed neighbours with rho ?

But the overall max_candidates is really interesting.

I think the origin paper missed a big detail, that the reversed neighbours would suffer from both too many and too little. 