### PR TITLE
Fix pyroma complaints

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,8 @@ configuration = {
     ],
     "keywords": "nearest neighbor, knn, ANN",
     "url": "http://github.com/lmcinnes/pynndescent",
+    "author": "Leland McInnes",
+    "author_email": "leland.mcinnes@gmail.com",
     "maintainer": "Leland McInnes",
     "maintainer_email": "leland.mcinnes@gmail.com",
     "license": "BSD",
@@ -40,6 +42,7 @@ configuration = {
     "test_suite": "nose.collector",
     "tests_require": ["nose"],
     "data_files": (),
+    "zip_safe": True,
 }
 
 setup(**configuration)


### PR DESCRIPTION
Relates to #48.

Pyroma thinks that the `author` and `author_email` fields should be present.

Also, `zip_safe` should be explicitly set. The default is `True`, so I've left it at that. I *think* it's [ok for `zip_safe = True`](https://setuptools.readthedocs.io/en/latest/setuptools.html#setting-the-zip-safe-flag), but I don't know what the effect of Numba is.