### PR TITLE
Use joblib for parallelization.

### DIFF
--- a/pynndescent/pynndescent_.py
+++ b/pynndescent/pynndescent_.py
@@ -531,9 +531,13 @@ class NNDescent(object):
             self._rp_forest = None
             leaf_array = np.array([[-1]])
 
-        if algorithm == "threaded":
+        if threaded.get_requested_n_jobs(n_jobs) != 1:
+            if algorithm != "standard":
+                raise ValueError(
+                    "Algorithm {} not supported in parallel mode".format(algorithm)
+                )
             if verbose:
-                print(ts(), "threaded NN descent for", str(n_iters), "iterations")
+                print(ts(), "parallel NN descent for", str(n_iters), "iterations")
             self._neighbor_graph = threaded.nn_descent(
                 self._raw_data,
                 self.n_neighbors,

--- a/pynndescent/pynndescent_.py
+++ b/pynndescent/pynndescent_.py
@@ -448,6 +448,11 @@ class NNDescent(object):
         indexes and less accurate searching. Don't tweak this value unless
         you know what you're doing.
 
+    n_jobs: int or None, optional (default=None)
+        The number of parallel jobs to run for neighbors index construction.
+        ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
+        ``-1`` means using all processors.
+
     verbose: bool (optional, default=False)
         Whether to print status data during the computation.
     """
@@ -469,7 +474,7 @@ class NNDescent(object):
         delta=0.001,
         rho=0.5,
         chunk_size=None,
-        threads=2,
+        n_jobs=None,
         seed_per_row=False,
         verbose=False,
     ):
@@ -543,7 +548,7 @@ class NNDescent(object):
                 rp_tree_init=self.tree_init,
                 leaf_array=leaf_array,
                 verbose=verbose,
-                threads=threads,
+                n_jobs=n_jobs,
                 seed_per_row=seed_per_row,
             )
         elif algorithm == "standard" or leaf_array.shape[0] == 1:

--- a/pynndescent/tests/test_threaded.py
+++ b/pynndescent/tests/test_threaded.py
@@ -1,3 +1,4 @@
+from joblib import Parallel
 import numpy as np
 
 from numpy.testing import assert_allclose
@@ -43,6 +44,7 @@ def test_init_current_graph():
     current_graph = pynndescent_.init_current_graph(
         data, dist, dist_args, n_neighbors, rng_state=new_rng_state(), seed_per_row=True
     )
+    parallel = Parallel(n_jobs=2, prefer="threads")
     current_graph_threaded = threaded.init_current_graph(
         data,
         dist,
@@ -50,6 +52,7 @@ def test_init_current_graph():
         n_neighbors,
         chunk_size=chunk_size,
         rng_state=new_rng_state(),
+        parallel=parallel,
         seed_per_row=True,
     )
 
@@ -80,14 +83,9 @@ def test_init_rp_tree():
     )
     _rp_forest = make_forest(data, n_neighbors, n_trees=8, rng_state=rng_state)
     leaf_array = rptree_leaf_array(_rp_forest)
+    parallel = Parallel(n_jobs=2, prefer="threads")
     threaded.init_rp_tree(
-        data,
-        dist,
-        dist_args,
-        current_graph_threaded,
-        leaf_array,
-        n_neighbors,
-        chunk_size,
+        data, dist, dist_args, current_graph_threaded, leaf_array, chunk_size, parallel
     )
 
     assert_allclose(current_graph_threaded, current_graph)
@@ -111,6 +109,7 @@ def test_new_build_candidates():
     current_graph = pynndescent_.init_current_graph(
         data, dist, dist_args, n_neighbors, rng_state=new_rng_state(), seed_per_row=True
     )
+    parallel = Parallel(n_jobs=2, prefer="threads")
     new_candidate_neighbors_threaded, old_candidate_neighbors_threaded = threaded.new_build_candidates(
         current_graph,
         n_vertices,
@@ -118,6 +117,8 @@ def test_new_build_candidates():
         max_candidates,
         chunk_size=chunk_size,
         rng_state=new_rng_state(),
+        rho=0.5,
+        parallel=parallel,
         seed_per_row=True,
     )
 
@@ -153,6 +154,7 @@ def test_nn_descent():
         seed_per_row=True,
         algorithm="threaded",
         chunk_size=chunk_size,
+        n_jobs=2,
     )._neighbor_graph
 
     for i in range(data.shape[0]):

--- a/pynndescent/tests/test_threaded.py
+++ b/pynndescent/tests/test_threaded.py
@@ -1,4 +1,4 @@
-from joblib import Parallel
+import joblib
 import numpy as np
 
 from numpy.testing import assert_allclose
@@ -40,11 +40,30 @@ def accuracy(expected, actual):
     )
 
 
+def test_get_requested_n_jobs():
+    assert_equal(threaded.get_requested_n_jobs(), 1, "Default to 1 job")
+    assert_equal(threaded.get_requested_n_jobs(2), 2, "Use n_jobs if specified")
+    with joblib.parallel_backend("threading"):
+        assert_equal(
+            threaded.get_requested_n_jobs(), -1, "Use all cores with context manager"
+        )
+    with joblib.parallel_backend("threading", n_jobs=3):
+        assert_equal(
+            threaded.get_requested_n_jobs(), 3, "Use n_jobs from context manager"
+        )
+    with joblib.parallel_backend("threading", n_jobs=3):
+        assert_equal(
+            threaded.get_requested_n_jobs(2),
+            2,
+            "Use n_jobs specified rather than from context manager",
+        )
+
+
 def test_init_current_graph():
     current_graph = pynndescent_.init_current_graph(
         data, dist, dist_args, n_neighbors, rng_state=new_rng_state(), seed_per_row=True
     )
-    parallel = Parallel(n_jobs=2, prefer="threads")
+    parallel = joblib.Parallel(n_jobs=2, prefer="threads")
     current_graph_threaded = threaded.init_current_graph(
         data,
         dist,
@@ -83,7 +102,7 @@ def test_init_rp_tree():
     )
     _rp_forest = make_forest(data, n_neighbors, n_trees=8, rng_state=rng_state)
     leaf_array = rptree_leaf_array(_rp_forest)
-    parallel = Parallel(n_jobs=2, prefer="threads")
+    parallel = joblib.Parallel(n_jobs=2, prefer="threads")
     threaded.init_rp_tree(
         data, dist, dist_args, current_graph_threaded, leaf_array, chunk_size, parallel
     )
@@ -109,7 +128,7 @@ def test_new_build_candidates():
     current_graph = pynndescent_.init_current_graph(
         data, dist, dist_args, n_neighbors, rng_state=new_rng_state(), seed_per_row=True
     )
-    parallel = Parallel(n_jobs=2, prefer="threads")
+    parallel = joblib.Parallel(n_jobs=2, prefer="threads")
     new_candidate_neighbors_threaded, old_candidate_neighbors_threaded = threaded.new_build_candidates(
         current_graph,
         n_vertices,
@@ -152,7 +171,6 @@ def test_nn_descent():
         delta=0,
         tree_init=False,
         seed_per_row=True,
-        algorithm="threaded",
         chunk_size=chunk_size,
         n_jobs=2,
     )._neighbor_graph

--- a/pynndescent/threaded.py
+++ b/pynndescent/threaded.py
@@ -1,4 +1,4 @@
-from joblib import Parallel
+import joblib
 import math
 import numba
 import numpy as np
@@ -31,6 +31,14 @@ def per_thread_rng_state(threads, rng_state):
 
 def parallel_calls(fn, n_tasks):
     return [(fn, [i], {}) for i in range(n_tasks)]
+
+
+def get_requested_n_jobs(n_jobs=None):
+    """Find the number of jobs, either specified directly, or from the joblib.parallel_backend context."""
+    if n_jobs is not None and n_jobs != 1:
+        return n_jobs
+    _, n_jobs_from_context = joblib.parallel.get_active_backend()
+    return n_jobs_from_context
 
 
 @numba.njit("i8[:](i8, i8, i8)", nogil=True)
@@ -561,7 +569,7 @@ def nn_descent(
     if rng_state is None:
         rng_state = new_rng_state()
 
-    with Parallel(prefer="threads", n_jobs=n_jobs) as parallel:
+    with joblib.Parallel(prefer="threads", n_jobs=n_jobs) as parallel:
 
         n_vertices = data.shape[0]
         n_tasks = int(math.ceil(float(n_vertices) / chunk_size))

--- a/pynndescent/threaded.py
+++ b/pynndescent/threaded.py
@@ -1,4 +1,4 @@
-import concurrent.futures
+from joblib import Parallel
 import math
 import numba
 import numpy as np
@@ -27,6 +27,10 @@ def new_rng_state():
 def per_thread_rng_state(threads, rng_state):
     """Create an array of per-thread RNG states, seeded from an initial rng_state."""
     return rejection_sample(threads * 3, INT32_MAX, rng_state).reshape((threads, 3))
+
+
+def parallel_calls(fn, n_tasks):
+    return [(fn, [i], {}) for i in range(n_tasks)]
 
 
 @numba.njit("i8[:](i8, i8, i8)", nogil=True)
@@ -125,7 +129,7 @@ def init_current_graph(
     n_neighbors,
     chunk_size,
     rng_state,
-    threads=2,
+    parallel,
     seed_per_row=False,
 ):
 
@@ -162,9 +166,8 @@ def init_current_graph(
             n_tasks, current_graph, heap_updates, offsets, index
         )
 
-    executor = concurrent.futures.ThreadPoolExecutor(max_workers=threads)
     # run map functions
-    for index, count in executor.map(current_graph_map, range(n_tasks)):
+    for index, count in parallel(parallel_calls(current_graph_map, n_tasks)):
         heap_update_counts[index] = count
 
     # sort and chunk heap updates so they can be applied in the reduce
@@ -176,12 +179,10 @@ def init_current_graph(
             heap_updates, heap_update_counts, offsets, chunk_size, n_vertices, index
         )
 
-    for _ in executor.map(shuffle, range(n_tasks)):
-        pass
+    parallel(parallel_calls(shuffle, n_tasks))
 
     # then run reduce functions
-    for _ in executor.map(current_graph_reduce, range(n_tasks)):
-        pass
+    parallel(parallel_calls(current_graph_reduce, n_tasks))
 
     return current_graph
 
@@ -240,7 +241,7 @@ def init_rp_tree_reduce_jit(n_tasks, current_graph, heap_updates, offsets, index
 
 
 def init_rp_tree(
-    data, dist, dist_args, current_graph, leaf_array, chunk_size, threads=2
+    data, dist, dist_args, current_graph, leaf_array, chunk_size, parallel
 ):
     n_vertices = data.shape[0]
     n_tasks = int(math.ceil(float(n_vertices) / chunk_size))
@@ -264,9 +265,8 @@ def init_rp_tree(
             n_tasks, current_graph, heap_updates, offsets, index
         )
 
-    executor = concurrent.futures.ThreadPoolExecutor(max_workers=threads)
     # run map functions
-    for index, count in executor.map(init_rp_tree_map, range(n_tasks)):
+    for index, count in parallel(parallel_calls(init_rp_tree_map, n_tasks)):
         heap_update_counts[index] = count
 
     # sort and chunk heap updates so they can be applied in the reduce
@@ -278,12 +278,10 @@ def init_rp_tree(
             heap_updates, heap_update_counts, offsets, chunk_size, n_vertices, index
         )
 
-    for _ in executor.map(shuffle, range(n_tasks)):
-        pass
+    parallel(parallel_calls(shuffle, n_tasks))
 
     # then run reduce functions
-    for _ in executor.map(init_rp_tree_reduce, range(n_tasks)):
-        pass
+    parallel(parallel_calls(init_rp_tree_reduce, n_tasks))
 
 
 @numba.njit("i8(i8[:], i8, f8[:, :, :], f8[:, :], i8, f8, i8[:], b1)", nogil=True)
@@ -370,8 +368,8 @@ def new_build_candidates(
     max_candidates,
     chunk_size,
     rng_state,
-    rho=0.5,
-    threads=2,
+    rho,
+    parallel,
     seed_per_row=False,
 ):
 
@@ -413,9 +411,8 @@ def new_build_candidates(
             index,
         )
 
-    executor = concurrent.futures.ThreadPoolExecutor(max_workers=threads)
     # run map functions
-    for index, count in executor.map(candidates_map, range(n_tasks)):
+    for index, count in parallel(parallel_calls(candidates_map, n_tasks)):
         heap_update_counts[index] = count
 
     # sort and chunk heap updates so they can be applied in the reduce
@@ -427,12 +424,10 @@ def new_build_candidates(
             heap_updates, heap_update_counts, offsets, chunk_size, n_vertices, index
         )
 
-    for _ in executor.map(shuffle, range(n_tasks)):
-        pass
+    parallel(parallel_calls(shuffle, n_tasks))
 
     # then run reduce functions
-    for _ in executor.map(candidates_reduce, range(n_tasks)):
-        pass
+    parallel(parallel_calls(candidates_reduce, n_tasks))
 
     return new_candidate_neighbors, old_candidate_neighbors
 
@@ -559,107 +554,110 @@ def nn_descent(
     rp_tree_init=False,
     leaf_array=None,
     verbose=False,
-    threads=2,
+    n_jobs=None,
     seed_per_row=False,
 ):
 
     if rng_state is None:
         rng_state = new_rng_state()
 
-    n_vertices = data.shape[0]
-    n_tasks = int(math.ceil(float(n_vertices) / chunk_size))
+    with Parallel(prefer="threads", n_jobs=n_jobs) as parallel:
 
-    current_graph = init_current_graph(
-        data,
-        dist,
-        dist_args,
-        n_neighbors,
-        chunk_size,
-        rng_state,
-        threads,
-        seed_per_row=seed_per_row,
-    )
+        n_vertices = data.shape[0]
+        n_tasks = int(math.ceil(float(n_vertices) / chunk_size))
 
-    if rp_tree_init:
-        init_rp_tree(
-            data, dist, dist_args, current_graph, leaf_array, chunk_size, threads
-        )
-
-    # store the updates in an array
-    # note that the factor here is `n_neighbors * n_neighbors`, not `max_candidates * max_candidates`
-    # since no more than `n_neighbors` candidates are added for each row
-    max_heap_update_count = chunk_size * n_neighbors * n_neighbors * 4
-    heap_updates = np.zeros((n_tasks, max_heap_update_count, 4))
-    heap_update_counts = np.zeros((n_tasks,), dtype=np.int64)
-
-    nn_descent_map_jit = make_nn_descent_map_jit(dist, dist_args)
-
-    executor = concurrent.futures.ThreadPoolExecutor(max_workers=threads)
-
-    for n in range(n_iters):
-        if verbose:
-            print("\t", n, " / ", n_iters)
-
-        (new_candidate_neighbors, old_candidate_neighbors) = new_build_candidates(
-            current_graph,
-            n_vertices,
+        current_graph = init_current_graph(
+            data,
+            dist,
+            dist_args,
             n_neighbors,
-            max_candidates,
             chunk_size,
             rng_state,
-            rho,
-            threads,
+            parallel,
             seed_per_row=seed_per_row,
         )
 
-        def nn_descent_map(index):
+        if rp_tree_init:
+            init_rp_tree(
+                data, dist, dist_args, current_graph, leaf_array, chunk_size, parallel
+            )
+
+        # store the updates in an array
+        # note that the factor here is `n_neighbors * n_neighbors`, not `max_candidates * max_candidates`
+        # since no more than `n_neighbors` candidates are added for each row
+        max_heap_update_count = chunk_size * n_neighbors * n_neighbors * 4
+        heap_updates = np.zeros((n_tasks, max_heap_update_count, 4))
+        heap_update_counts = np.zeros((n_tasks,), dtype=np.int64)
+
+        nn_descent_map_jit = make_nn_descent_map_jit(dist, dist_args)
+
+        for n in range(n_iters):
+            if verbose:
+                print("\t", n, " / ", n_iters)
+
+            (new_candidate_neighbors, old_candidate_neighbors) = new_build_candidates(
+                current_graph,
+                n_vertices,
+                n_neighbors,
+                max_candidates,
+                chunk_size,
+                rng_state,
+                rho,
+                parallel,
+                seed_per_row=seed_per_row,
+            )
+
+            def nn_descent_map(index):
+                rows = chunk_rows(chunk_size, index, n_vertices)
+                return (
+                    index,
+                    nn_descent_map_jit(
+                        rows,
+                        max_candidates,
+                        data,
+                        new_candidate_neighbors,
+                        old_candidate_neighbors,
+                        heap_updates[index],
+                        offset=0,
+                    ),
+                )
+
+            def nn_decent_reduce(index):
+                return nn_decent_reduce_jit(
+                    n_tasks, current_graph, heap_updates, offsets, index
+                )
+
+            # run map functions
+            for index, count in parallel(parallel_calls(nn_descent_map, n_tasks)):
+                heap_update_counts[index] = count
+
+            # sort and chunk heap updates so they can be applied in the reduce
+            max_count = heap_update_counts.max()
+            offsets = np.zeros((n_tasks, max_count), dtype=np.int64)
+
+            def shuffle(index):
+                return shuffle_jit(
+                    heap_updates,
+                    heap_update_counts,
+                    offsets,
+                    chunk_size,
+                    n_vertices,
+                    index,
+                )
+
+            parallel(parallel_calls(shuffle, n_tasks))
+
+            # then run reduce functions
+            c = 0
+            for c_part in parallel(parallel_calls(nn_decent_reduce, n_tasks)):
+                c += c_part
+
+            if c <= delta * n_neighbors * data.shape[0]:
+                break
+
+        def deheap_sort_map(index):
             rows = chunk_rows(chunk_size, index, n_vertices)
-            return (
-                index,
-                nn_descent_map_jit(
-                    rows,
-                    max_candidates,
-                    data,
-                    new_candidate_neighbors,
-                    old_candidate_neighbors,
-                    heap_updates[index],
-                    offset=0,
-                ),
-            )
+            return index, deheap_sort_map_jit(rows, current_graph)
 
-        def nn_decent_reduce(index):
-            return nn_decent_reduce_jit(
-                n_tasks, current_graph, heap_updates, offsets, index
-            )
-
-        # run map functions
-        for index, count in executor.map(nn_descent_map, range(n_tasks)):
-            heap_update_counts[index] = count
-
-        # sort and chunk heap updates so they can be applied in the reduce
-        max_count = heap_update_counts.max()
-        offsets = np.zeros((n_tasks, max_count), dtype=np.int64)
-
-        def shuffle(index):
-            return shuffle_jit(
-                heap_updates, heap_update_counts, offsets, chunk_size, n_vertices, index
-            )
-
-        for _ in executor.map(shuffle, range(n_tasks)):
-            pass
-
-        # then run reduce functions
-        c = 0
-        for c_part in executor.map(nn_decent_reduce, range(n_tasks)):
-            c += c_part
-
-        if c <= delta * n_neighbors * data.shape[0]:
-            break
-
-    def deheap_sort_map(index):
-        rows = chunk_rows(chunk_size, index, n_vertices)
-        return index, deheap_sort_map_jit(rows, current_graph)
-
-    for _ in executor.map(deheap_sort_map, range(n_tasks)):
-        pass
-    return current_graph[0].astype(np.int64), current_graph[1]
+        parallel(parallel_calls(deheap_sort_map, n_tasks))
+        return current_graph[0].astype(np.int64), current_graph[1]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+joblib
 scikit-learn>=0.18
 scipy>=1.0
 numba>=0.39


### PR DESCRIPTION
This replaces `concurrent.futures.ThreadPoolExecutor` with [joblib](https://joblib.readthedocs.io/en/latest/index.html). Joblib is used by scikit-learn, and has other backends, such as multiprocessing and Dask, which could be attractive in the future. I have benchmarked the threading backend with up to 64 threads and a range of data sizes (up to 1M rows) and the results are comparable with `ThreadPoolExecutor`.

Another nice thing about Joblib is that it allows parallelism to be specified outside the library using a [context manager](https://joblib.readthedocs.io/en/latest/parallel.html#joblib.parallel_backend). So for UMAP you could run with threads using something like this (once UMAP uses pynndescent of course):

```python
with parallel_backend('threading', n_jobs=8):
  embedding = UMAP().fit_transform(X)
```

This PR doesn't quite get there however. I think we need to do something like look to see if `n_jobs` is set, and if so use the parallel implementation. This would mean removing the `threaded` keyword for the algorithm, which is probably the right thing as algorithm and backend are different concepts.

I'm also wondering about renaming `threaded.py` to `parallel.py` to reflect the fact that it's more general now.

Also, in terms of the API, I am considering removing `chunk_size` and just dividing the size of the data matrix rows into the number of jobs, which is the default now, and not something I've ever needed to change. (We could add it back in if it is ever needed.)
