### PR TITLE
appveyor: use requirements.txt for dependencies

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,8 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - "conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy scikit-learn numba nose"
+  - "conda create -q -n test-environment python=%PYTHON_VERSION% nose"
+  - pip install -r requirements.txt
   - activate test-environment
   - pip install -e .
 


### PR DESCRIPTION
Windows CI is not picking up dependencies automatically, because we were installing them via conda. Instead, use `pip` and `requirements.txt`.