### PR TITLE
Add joblib to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ configuration = {
     "maintainer_email": "leland.mcinnes@gmail.com",
     "license": "BSD",
     "packages": ["pynndescent"],
-    "install_requires": ["scikit-learn >= 0.18", "scipy >= 1.0", "numba >= 0.39"],
+    "install_requires": ["scikit-learn >= 0.18", "scipy >= 1.0", "numba >= 0.39", "joblib >= 0.11"],
     "ext_modules": [],
     "cmdclass": {},
     "test_suite": "nose.collector",


### PR DESCRIPTION
`scikit-learn` (<0.21) does not explicitly declare joblib as an external dependency (https://github.com/scikit-learn/scikit-learn/pull/13531).