### PR TITLE
Start fix for tranformer return shape

### DIFF
--- a/pynndescent/pynndescent_.py
+++ b/pynndescent/pynndescent_.py
@@ -1024,7 +1024,7 @@ class PyNNDescentTransformer(BaseEstimator, TransformerMixin):
 
         Returns
         -------
-        Xt : CSR sparse matrix, shape (n_samples_fit, n_samples_transform)
+        Xt : CSR sparse matrix, shape (n_samples_transform, n_samples_fit)
             Xt[i, j] is assigned the weight of edge that connects i to j.
             Only the neighbors have an explicit value.
         """
@@ -1042,7 +1042,7 @@ class PyNNDescentTransformer(BaseEstimator, TransformerMixin):
             )
 
         result = lil_matrix(
-            (n_samples_transform, n_samples_transform), dtype=np.float32
+            (n_samples_transform, self.n_samples_fit), dtype=np.float32
         )
         result.rows = indices
         result.data = distances

--- a/pynndescent/pynndescent_.py
+++ b/pynndescent/pynndescent_.py
@@ -1041,9 +1041,7 @@ class PyNNDescentTransformer(BaseEstimator, TransformerMixin):
                 X, k=self.n_neighbors, queue_size=self.search_queue_size
             )
 
-        result = lil_matrix(
-            (n_samples_transform, self.n_samples_fit), dtype=np.float32
-        )
+        result = lil_matrix((n_samples_transform, self.n_samples_fit), dtype=np.float32)
         result.rows = indices
         result.data = distances
 

--- a/pynndescent/tests/test_pynndescent_.py
+++ b/pynndescent/tests/test_pynndescent_.py
@@ -160,24 +160,16 @@ def test_transformer_equivalence():
     train = nn_data[:400]
     test = nn_data[:200]
 
-    nnd = NNDescent(
-        data=train,
-        n_neighbors=N_NEIGHBORS,
-        random_state=42
-    )
+    nnd = NNDescent(data=train, n_neighbors=N_NEIGHBORS, random_state=42)
     indices, dists = nnd.query(test, k=N_NEIGHBORS, queue_size=QUEUE_SIZE)
     sort_idx = np.argsort(indices, axis=1)
     indices_sorted = np.vstack(
-         [indices[i, sort_idx[i]] for i in range(sort_idx.shape[0])]
+        [indices[i, sort_idx[i]] for i in range(sort_idx.shape[0])]
     )
-    dists_sorted = np.vstack(
-        [dists[i, sort_idx[i]] for i in range(sort_idx.shape[0])]
-    )
+    dists_sorted = np.vstack([dists[i, sort_idx[i]] for i in range(sort_idx.shape[0])])
 
     transformer = PyNNDescentTransformer(
-        n_neighbors=N_NEIGHBORS,
-        search_queue_size=QUEUE_SIZE,
-        random_state=42
+        n_neighbors=N_NEIGHBORS, search_queue_size=QUEUE_SIZE, random_state=42
     ).fit(train)
     Xt = transformer.transform(test).sorted_indices()
 


### PR DESCRIPTION
Fixes #73 

Still needs a test, but I can add that tomorrow.

I've also reversed the dimensions specified by the `.transform` docs since a) I'm using the indices as they're returned and b) it fits the API of `KNeighborsTransformer` this way.