### PR TITLE
Fix docstring for parameter 'rho'

### DIFF
--- a/pynndescent/pynndescent_.py
+++ b/pynndescent/pynndescent_.py
@@ -571,7 +571,7 @@ class NNDescent(object):
 
     rho: float (optional, default=0.5)
         Controls the random sampling of potential candidates in any given
-        iteration of NN-descent. Larger values will result in less accurate
+        iteration of NN-descent. Smaller values will result in less accurate
         indexes and less accurate searching. Don't tweak this value unless
         you know what you're doing.
 


### PR DESCRIPTION
Just a minor issue that I noticed while reading the docstring for `NNDescent`. According to the NN-descent paper, larger values of constant `rho` lead to more accurate indexes at the cost of more computation. In case your code definition of `rho` is the different from the paper's definition, please ignore and I will close the PR :). 