### PR TITLE
Include license in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include LICENSE
+include *.md
+include *.rst
+include requirements.txt
+recursive-include pynndescent *


### PR DESCRIPTION
The terms of the BSD-2-Clause license requires it.  Also include tests, requirements.txt, and a few additional documentation files.