### PR TITLE
fix types: int64->intp

### DIFF
--- a/pynndescent/distances.py
+++ b/pynndescent/distances.py
@@ -47,7 +47,7 @@ def euclidean(x, y):
     locals={
         "result": numba.types.float32,
         "diff": numba.types.float32,
-        "dim": numba.types.int64,
+        "dim": numba.types.intp,
         "i": numba.types.uint16,
     },
 )
@@ -230,7 +230,7 @@ def jaccard(x, y):
         "num_equal": numba.types.float32,
         "x_true": numba.types.uint8,
         "y_true": numba.types.uint8,
-        "dim": numba.types.int64,
+        "dim": numba.types.intp,
         "i": numba.types.uint16,
     },
 )
@@ -415,7 +415,7 @@ def cosine(x, y):
         "result": numba.types.float32,
         "norm_x": numba.types.float32,
         "norm_y": numba.types.float32,
-        "dim": numba.types.int64,
+        "dim": numba.types.intp,
         "i": numba.types.uint16,
     },
 )
@@ -445,7 +445,7 @@ def alternative_cosine(x, y):
     fastmath=True,
     locals={
         "result": numba.types.float32,
-        "dim": numba.types.int64,
+        "dim": numba.types.intp,
         "i": numba.types.uint16,
     },
 )
@@ -472,7 +472,7 @@ def dot(x, y):
     fastmath=True,
     locals={
         "result": numba.types.float32,
-        "dim": numba.types.int64,
+        "dim": numba.types.intp,
         "i": numba.types.uint16,
     },
 )
@@ -589,7 +589,7 @@ def correlation(x, y):
         "result": numba.types.float32,
         "l1_norm_x": numba.types.float32,
         "l1_norm_y": numba.types.float32,
-        "dim": numba.types.int64,
+        "dim": numba.types.intp,
         "i": numba.types.uint16,
     },
 )
@@ -625,7 +625,7 @@ def hellinger(x, y):
         "result": numba.types.float32,
         "l1_norm_x": numba.types.float32,
         "l1_norm_y": numba.types.float32,
-        "dim": numba.types.int64,
+        "dim": numba.types.intp,
         "i": numba.types.uint16,
     },
 )

--- a/pynndescent/rp_trees.py
+++ b/pynndescent/rp_trees.py
@@ -853,7 +853,7 @@ def make_sparse_tree(inds, indptr, spdata, rng_state, leaf_size=30, angular=Fals
     fastmath=True,
     locals={
         "margin": numba.types.float32,
-        "dim": numba.types.int64,
+        "dim": numba.types.intp,
         "d": numba.types.uint16,
     },
 )

--- a/pynndescent/sparse.py
+++ b/pynndescent/sparse.py
@@ -218,7 +218,7 @@ def sparse_euclidean(ind1, data1, ind2, data2):
         "aux_data": numba.types.float32[::1],
         "result": numba.types.float32,
         "diff": numba.types.float32,
-        "dim": numba.types.int64,
+        "dim": numba.types.intp,
         "i": numba.types.uint16,
     },
 )
@@ -336,8 +336,8 @@ def sparse_jaccard(ind1, data1, ind2, data2):
     ],
     fastmath=True,
     locals={
-        "num_non_zero": numba.types.int64,
-        "num_equal": numba.types.int64,
+        "num_non_zero": numba.types.intp,
+        "num_equal": numba.types.intp,
     },
 )
 def sparse_alternative_jaccard(ind1, data1, ind2, data2):
@@ -458,7 +458,7 @@ def sparse_cosine(ind1, data1, ind2, data2):
         "result": numba.types.float32,
         "norm_x": numba.types.float32,
         "norm_y": numba.types.float32,
-        "dim": numba.types.int64,
+        "dim": numba.types.intp,
         "i": numba.types.uint16,
     },
 )
@@ -505,7 +505,7 @@ def sparse_dot(ind1, data1, ind2, data2):
     fastmath=True,
     locals={
         "result": numba.types.float32,
-        "dim": numba.types.int64,
+        "dim": numba.types.intp,
         "i": numba.types.uint16,
     },
 )
@@ -611,7 +611,7 @@ def sparse_hellinger(ind1, data1, ind2, data2):
         "result": numba.types.float32,
         "l1_norm_x": numba.types.float32,
         "l1_norm_y": numba.types.float32,
-        "dim": numba.types.int64,
+        "dim": numba.types.intp,
         "i": numba.types.uint16,
     },
 )

--- a/pynndescent/utils.py
+++ b/pynndescent/utils.py
@@ -67,7 +67,7 @@ def tau_rand(state):
         ),
     ],
     locals={
-        "dim": numba.types.uint64,
+        "dim": numba.types.intp,
         "i": numba.types.uint32,
         "result": numba.types.float32,
     },
@@ -620,7 +620,7 @@ def mark_visited(table, candidate):
     "i4(f4[::1],i4[::1],f4,i4)",
     fastmath=True,
     locals={
-        "size": numba.types.int64,
+        "size": numba.types.intp,
         "i": numba.types.uint16,
         "ic1": numba.types.uint16,
         "ic2": numba.types.uint16,
@@ -676,7 +676,7 @@ def simple_heap_push(priorities, indices, p, n):
     "i4(f4[::1],i4[::1],f4,i4)",
     fastmath=True,
     locals={
-        "size": numba.types.int64,
+        "size": numba.types.intp,
         "i": numba.types.uint16,
         "ic1": numba.types.uint16,
         "ic2": numba.types.uint16,
@@ -737,7 +737,7 @@ def checked_heap_push(priorities, indices, p, n):
     "i4(f4[::1],i4[::1],u1[::1],f4,i4,u1)",
     fastmath=True,
     locals={
-        "size": numba.types.int64,
+        "size": numba.types.intp,
         "i": numba.types.uint16,
         "ic1": numba.types.uint16,
         "ic2": numba.types.uint16,
@@ -796,7 +796,7 @@ def flagged_heap_push(priorities, indices, flags, p, n, f):
     "i4(f4[::1],i4[::1],u1[::1],f4,i4,u1)",
     fastmath=True,
     locals={
-        "size": numba.types.int64,
+        "size": numba.types.intp,
         "i": numba.types.uint16,
         "ic1": numba.types.uint16,
         "ic2": numba.types.uint16,


### PR DESCRIPTION
As `intp` is the more portable option.

Followup from #113 