### PR TITLE
Dropping Nose dependency and PyTest migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,13 @@ sudo: false
 python:
   - "3.6"
   - "3.7"
+  - "3.8"
 env:
   global:
     - MODULE=pynndescent
   matrix:
     - COVERAGE="false"
-#    - COVERAGE="true"
+    - COVERAGE="true"
 #matrix:
 #  exclude:
 #    - python: "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
     - MODULE=pynndescent
   matrix:
     - COVERAGE="false"
-    - COVERAGE="true"
+#    - COVERAGE="true"
 #matrix:
 #  exclude:
 #    - python: "3.6"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
     - PYTHON_VERSION: "3.7"
       MINICONDA: C:\Miniconda3-x64
     - PYTHON_VERSION: "3.8"
-        MINICONDA: C:\Miniconda3-x64
+      MINICONDA: C:\Miniconda3-x64
 
 init:
   - "ECHO %PYTHON_VERSION% %MINICONDA%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,8 @@ environment:
       MINICONDA: C:\Miniconda36-x64
     - PYTHON_VERSION: "3.7"
       MINICONDA: C:\Miniconda3-x64
+    - PYTHON_VERSION: "3.8"
+        MINICONDA: C:\Miniconda3-x64
 
 init:
   - "ECHO %PYTHON_VERSION% %MINICONDA%"
@@ -15,11 +17,11 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - "conda create -q -n test-environment python=%PYTHON_VERSION% nose"
+  - "conda create -q -n test-environment python=%PYTHON_VERSION% pytest"
   - pip install -r requirements.txt
   - activate test-environment
   - pip install -e .
 
 test_script:
-  - nosetests
+  - pytest --show-capture=no -v --disable-warnings
   

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,6 +47,6 @@ steps:
 
 - task: PublishTestResults@2
   inputs:
-    testResultsFiles: 'pytest.xml'
+    testResultsFiles: 'coverage.xml'
     testRunTitle: '$(Agent.OS) - $(Build.BuildNumber)[$(Agent.JobName)] - Python $(python.version)'
   condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,6 +16,9 @@ strategy:
     mac10.14_py37:
       imageName: 'macOS-10.14'
       python.version: '3.7'
+    mac10.14_py38:
+      imageName: 'macOS-10.14'
+      python.version: '3.8'
 
 pool:
   vmImage: $(imageName)
@@ -33,15 +36,17 @@ steps:
 
 - script: |
     pip install -e .
+    pip install pytest
+    pip install pytest-cov
+    pip install coveralls
   displayName: 'Install package'
 
 - script: |
-    pip install nose
-    nosetests -s -v --with-xunit
+    pytest pynndescent/tests --show-capture=no -v --disable-warnings --junitxml=junit/test-results.xml --cov=pynndescent/ --cov-report=xml --cov-report=html
   displayName: 'Run tests'
 
 - task: PublishTestResults@2
   inputs:
-    testResultsFiles: 'nosetests.xml'
+    testResultsFiles: 'pytest.xml'
     testRunTitle: '$(Agent.OS) - $(Build.BuildNumber)[$(Agent.JobName)] - Python $(python.version)'
   condition: succeededOrFailed()

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -4,7 +4,7 @@ pip install -r requirements.txt
 pip install black
 
 if [[ "${COVERAGE}" == "true" ]]; then
-    pip install coverage coveralls
+    pip install pytest-cov coveralls
 fi
 
 pip install -e .

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -3,7 +3,7 @@ set -e
 COVERAGE_ARGS=""
 if [[ "${COVERAGE}" == "true" ]]; then
     export NUMBA_DISABLE_JIT=1
-    COVERAGE_ARGS="--cov=${MODULE}"
+    COVERAGE_ARGS="--junitxml=junit/test-results.xml --cov=pynndescent/ --cov-report=xml --cov-report=html"
 fi
 
-pytest --show-capture=no -v --disable-warnings ${COVERAGE_ARGS} ${MODULE} && black --diff ${MODULE} && black --check ${MODULE}
+pytest ${MODULE} --show-capture=no -v --disable-warnings ${COVERAGE_ARGS} && black --diff ${MODULE} && black --check ${MODULE}

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -3,7 +3,7 @@ set -e
 COVERAGE_ARGS=""
 if [[ "${COVERAGE}" == "true" ]]; then
     export NUMBA_DISABLE_JIT=1
-    COVERAGE_ARGS="--with-coverage --cover-package=${MODULE}"
+    COVERAGE_ARGS="--cov=${MODULE}"
 fi
 
-nosetests -s -v ${COVERAGE_ARGS} ${MODULE} && black --diff ${MODULE} && black --check ${MODULE}
+pytest --show-capture=no -v --disable-warnings ${COVERAGE_ARGS} ${MODULE} && black --diff ${MODULE} && black --check ${MODULE}

--- a/pynndescent/tests/conftest.py
+++ b/pynndescent/tests/conftest.py
@@ -1,0 +1,63 @@
+import os
+import pytest
+import numpy as np
+from scipy import sparse
+
+# Making Random Seed as a fixture in case it would be
+# needed in tests for random states
+@pytest.fixture
+def seed():
+    return 189212  # 0b101110001100011100
+
+
+np.random.seed(189212)
+
+
+@pytest.fixture
+def spatial_data():
+    sp_data = np.random.randn(10, 20)
+    # Add some all zero graph_data for corner case test
+    sp_data = np.vstack([sp_data, np.zeros((2, 20))]).astype(np.float32, order="C")
+    return sp_data
+
+
+@pytest.fixture
+def binary_data():
+    bin_data = np.random.choice(a=[False, True], size=(10, 20), p=[0.66, 1 - 0.66])
+    # Add some all zero graph_data for corner case test
+    bin_data = np.vstack([bin_data, np.zeros((2, 20), dtype="bool")])
+    return bin_data
+
+
+@pytest.fixture
+def sparse_spatial_data(spatial_data, binary_data):
+    sp_sparse_data = sparse.csr_matrix(spatial_data * binary_data, dtype=np.float32)
+    sp_sparse_data.sort_indices()
+    return sp_sparse_data
+
+
+@pytest.fixture
+def sparse_binary_data(binary_data):
+    bin_sparse_data = sparse.csr_matrix(binary_data)
+    bin_sparse_data.sort_indices()
+    return bin_sparse_data
+
+
+@pytest.fixture
+def nn_data():
+    nndata = np.random.uniform(0, 1, size=(1000, 5))
+    # Add some all zero graph_data for corner case test
+    nndata = np.vstack([nndata, np.zeros((2, 5))])
+    return nndata
+
+
+@pytest.fixture
+def sparse_nn_data():
+    return sparse.random(1000, 50, density=0.5, format="csr")
+
+
+@pytest.fixture
+def cosine_hang_data():
+    this_dir = os.path.dirname(os.path.abspath(__file__))
+    data_path = os.path.join(this_dir, "test_data/cosine_hang.npy")
+    return np.load(data_path)

--- a/pynndescent/tests/test_distances.py
+++ b/pynndescent/tests/test_distances.py
@@ -1,27 +1,28 @@
+import pytest
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 import pynndescent.distances as dist
 import pynndescent.sparse as spdist
-from scipy import sparse, stats
+from scipy import stats
 from sklearn.metrics import pairwise_distances
 from sklearn.neighbors import BallTree
 
-np.random.seed(42)
-spatial_data = np.random.randn(10, 20)
-spatial_data = np.vstack([spatial_data, np.zeros((2, 20))]).astype(
-    np.float32, order="C"
-)  # Add some all zero graph_data for corner case test
-binary_data = np.random.choice(a=[False, True], size=(10, 20), p=[0.66, 1 - 0.66])
-binary_data = np.vstack(
-    [binary_data, np.zeros((2, 20), dtype="bool")]
-)  # Add some all zero graph_data for corner case test
-sparse_spatial_data = sparse.csr_matrix(spatial_data * binary_data, dtype=np.float32)
-sparse_spatial_data.sort_indices()
-sparse_binary_data = sparse.csr_matrix(binary_data)
-sparse_binary_data.sort_indices()
 
-
-def spatial_check(metric):
+@pytest.mark.parametrize(
+    "metric",
+    [
+        "euclidean",
+        "manhattan",
+        "chebyshev",
+        "minkowski",
+        "hamming",
+        "canberra",
+        "braycurtis",
+        "cosine",
+        "correlation",
+    ],
+)
+def test_spatial_check(spatial_data, metric):
     dist_matrix = pairwise_distances(spatial_data, metric=metric)
     # scipy is bad sometimes
     if metric == "braycurtis":
@@ -48,7 +49,21 @@ def spatial_check(metric):
     )
 
 
-def binary_check(metric):
+@pytest.mark.parametrize(
+    "metric",
+    [
+        "jaccard",
+        "matching",
+        "dice",
+        "kulsinski",
+        "rogerstanimoto",
+        "russellrao",
+        "sokalmichener",
+        "sokalsneath",
+        "yule",
+    ],
+)
+def test_binary_check(binary_data, metric):
     dist_matrix = pairwise_distances(binary_data, metric=metric)
     if metric in ("jaccard", "dice", "sokalsneath", "yule"):
         dist_matrix[np.where(~np.isfinite(dist_matrix))] = 0.0
@@ -74,7 +89,21 @@ def binary_check(metric):
     )
 
 
-def sparse_spatial_check(metric, decimal=6):
+@pytest.mark.parametrize(
+    "metric",
+    [
+        "euclidean",
+        "manhattan",
+        "chebyshev",
+        "minkowski",
+        "hamming",
+        "canberra",
+        "cosine",
+        "braycurtis",
+        "correlation",
+    ],
+)
+def test_sparse_spatial_check(sparse_spatial_data, metric, decimal=6):
     if metric in spdist.sparse_named_distances:
         dist_matrix = pairwise_distances(
             sparse_spatial_data.todense().astype(np.float32), metric=metric
@@ -127,10 +156,23 @@ def sparse_spatial_check(metric, decimal=6):
     )
 
 
-def sparse_binary_check(metric):
+@pytest.mark.parametrize(
+    "metric",
+    [
+        "jaccard",
+        "matching",
+        "dice",
+        "kulsinski",
+        "rogerstanimoto",
+        "russellrao",
+        "sokalmichener",
+        "sokalsneath",
+    ],
+)
+def test_sparse_binary_check(sparse_binary_data, metric):
     if metric in spdist.sparse_named_distances:
         dist_matrix = pairwise_distances(sparse_binary_data.todense(), metric=metric)
-    if metric in ("jaccard", "dice", "sokalsneath", "yule"):
+    if metric in ("jaccard", "dice", "sokalsneath"):
         dist_matrix[np.where(~np.isfinite(dist_matrix))] = 0.0
     if metric in ("kulsinski", "russellrao"):
         dist_matrix[np.where(~np.isfinite(dist_matrix))] = 1.0
@@ -178,147 +220,7 @@ def sparse_binary_check(metric):
     )
 
 
-def test_euclidean():
-    spatial_check("euclidean")
-
-
-def test_manhattan():
-    spatial_check("manhattan")
-
-
-def test_chebyshev():
-    spatial_check("chebyshev")
-
-
-def test_minkowski():
-    spatial_check("minkowski")
-
-
-def test_hamming():
-    spatial_check("hamming")
-
-
-def test_canberra():
-    spatial_check("canberra")
-
-
-def test_braycurtis():
-    spatial_check("braycurtis")
-
-
-def test_cosine():
-    spatial_check("cosine")
-
-
-def test_correlation():
-    spatial_check("correlation")
-
-
-def test_jaccard():
-    binary_check("jaccard")
-
-
-def test_matching():
-    binary_check("matching")
-
-
-def test_dice():
-    binary_check("dice")
-
-
-def test_kulsinski():
-    binary_check("kulsinski")
-
-
-def test_rogerstanimoto():
-    binary_check("rogerstanimoto")
-
-
-def test_russellrao():
-    binary_check("russellrao")
-
-
-def test_sokalmichener():
-    binary_check("sokalmichener")
-
-
-def test_sokalsneath():
-    binary_check("sokalsneath")
-
-
-def test_yule():
-    binary_check("yule")
-
-
-def test_sparse_euclidean():
-    sparse_spatial_check("euclidean")
-
-
-def test_sparse_manhattan():
-    sparse_spatial_check("manhattan")
-
-
-def test_sparse_chebyshev():
-    sparse_spatial_check("chebyshev")
-
-
-def test_sparse_minkowski():
-    sparse_spatial_check("minkowski")
-
-
-def test_sparse_hamming():
-    sparse_spatial_check("hamming")
-
-
-def test_sparse_canberra():
-    sparse_spatial_check("canberra")  # Be a little forgiving
-
-
-def test_sparse_cosine():
-    sparse_spatial_check("cosine")
-
-
-def test_sparse_correlation():
-    sparse_spatial_check("correlation")
-
-
-def test_sparse_jaccard():
-    sparse_binary_check("jaccard")
-
-
-def test_sparse_matching():
-    sparse_binary_check("matching")
-
-
-def test_sparse_dice():
-    sparse_binary_check("dice")
-
-
-def test_sparse_kulsinski():
-    sparse_binary_check("kulsinski")
-
-
-def test_sparse_rogerstanimoto():
-    sparse_binary_check("rogerstanimoto")
-
-
-def test_sparse_russellrao():
-    sparse_binary_check("russellrao")
-
-
-def test_sparse_sokalmichener():
-    sparse_binary_check("sokalmichener")
-
-
-def test_sparse_sokalsneath():
-    sparse_binary_check("sokalsneath")
-
-
-def test_sparse_braycurtis():
-    sparse_spatial_check("braycurtis")
-
-
-def test_seuclidean():
+def test_seuclidean(spatial_data):
     v = np.abs(np.random.randn(spatial_data.shape[1]))
     dist_matrix = pairwise_distances(spatial_data, metric="seuclidean", V=v)
     test_matrix = np.array(
@@ -337,7 +239,7 @@ def test_seuclidean():
     )
 
 
-def test_weighted_minkowski():
+def test_weighted_minkowski(spatial_data):
     v = np.abs(np.random.randn(spatial_data.shape[1]))
     dist_matrix = pairwise_distances(spatial_data, metric="wminkowski", w=v, p=3)
     test_matrix = np.array(
@@ -356,7 +258,7 @@ def test_weighted_minkowski():
     )
 
 
-def test_mahalanobis():
+def test_mahalanobis(spatial_data):
     v = np.cov(np.transpose(spatial_data))
     dist_matrix = pairwise_distances(spatial_data, metric="mahalanobis", VI=v)
     test_matrix = np.array(
@@ -375,7 +277,7 @@ def test_mahalanobis():
     )
 
 
-def test_haversine():
+def test_haversine(spatial_data):
     tree = BallTree(spatial_data[:, :2], metric="haversine")
     dist_matrix, _ = tree.query(spatial_data[:, :2], k=spatial_data.shape[0])
     test_matrix = np.array(

--- a/pynndescent/tests/test_pynndescent_.py
+++ b/pynndescent/tests/test_pynndescent_.py
@@ -354,7 +354,13 @@ def test_pickle_unpickle():
     x1 = seed.normal(0, 100, (1000, 50))
     x2 = seed.normal(0, 100, (1000, 50))
 
-    index1 = NNDescent(x1, "euclidean", {}, 10, random_state=None,)
+    index1 = NNDescent(
+        x1,
+        "euclidean",
+        {},
+        10,
+        random_state=None,
+    )
     neighbors1, distances1 = index1.query(x2)
 
     pickle.dump(index1, open("test_tmp.pkl", "wb"))
@@ -373,7 +379,14 @@ def test_compressed_pickle_unpickle():
     x1 = seed.normal(0, 100, (1000, 50))
     x2 = seed.normal(0, 100, (1000, 50))
 
-    index1 = NNDescent(x1, "euclidean", {}, 10, random_state=None, compressed=True,)
+    index1 = NNDescent(
+        x1,
+        "euclidean",
+        {},
+        10,
+        random_state=None,
+        compressed=True,
+    )
     neighbors1, distances1 = index1.query(x2)
 
     pickle.dump(index1, open("test_tmp.pkl", "wb"))
@@ -411,7 +424,13 @@ def test_joblib_dump():
     x1 = seed.normal(0, 100, (1000, 50))
     x2 = seed.normal(0, 100, (1000, 50))
 
-    index1 = NNDescent(x1, "euclidean", {}, 10, random_state=None,)
+    index1 = NNDescent(
+        x1,
+        "euclidean",
+        {},
+        10,
+        random_state=None,
+    )
     neighbors1, distances1 = index1.query(x2)
 
     joblib.dump(index1, "test_tmp.dump")

--- a/pynndescent/tests/test_pynndescent_.py
+++ b/pynndescent/tests/test_pynndescent_.py
@@ -1,13 +1,10 @@
 import os
 import io
 import re
+import pytest
 from contextlib import redirect_stdout
 
-from nose.tools import assert_greater_equal, assert_true, assert_equal
-from nose import SkipTest
-
 import numpy as np
-from scipy import sparse
 from sklearn.neighbors import KDTree
 from sklearn.neighbors import NearestNeighbors
 from sklearn.preprocessing import normalize
@@ -16,29 +13,10 @@ import joblib
 
 from pynndescent import NNDescent, PyNNDescentTransformer
 
-np.random.seed(42)
-spatial_data = np.random.randn(10, 20)
-spatial_data = np.vstack(
-    [spatial_data, np.zeros((2, 20))]
-)  # Add some all zero graph_data for corner case test
 
-nn_data = np.random.uniform(0, 1, size=(1000, 5))
-nn_data = np.vstack(
-    [nn_data, np.zeros((2, 5))]
-)  # Add some all zero graph_data for corner case test
-# for_sparse_nn_data = np.random.uniform(0, 1, size=(1002, 500))
-# binary_nn_data = np.random.choice(a=[False, True], size=(1000, 500), p=[0.1, 1 - 0.1])
-# binary_nn_data = np.vstack(
-#     [binary_nn_data, np.zeros((2, 500))]
-# )  # Add some all zero graph_data for corner case test
-# sparse_nn_data = sparse.csr_matrix(for_sparse_nn_data * binary_nn_data)
-sparse_nn_data = sparse.random(1000, 50, density=0.5, format="csr")
-# sparse_nn_data = sparse.csr_matrix(nn_data)
-
-
-def test_nn_descent_neighbor_accuracy():
+def test_nn_descent_neighbor_accuracy(nn_data, seed):
     knn_indices, _ = NNDescent(
-        nn_data, "euclidean", {}, 10, random_state=np.random
+        nn_data, "euclidean", {}, 10, random_state=np.random.RandomState(seed)
     )._neighbor_graph
 
     tree = KDTree(nn_data)
@@ -49,16 +27,14 @@ def test_nn_descent_neighbor_accuracy():
         num_correct += np.sum(np.in1d(true_indices[i], knn_indices[i]))
 
     percent_correct = num_correct / (nn_data.shape[0] * 10)
-    assert_greater_equal(
-        percent_correct,
-        0.98,
-        "NN-descent did not get 99% " "accuracy on nearest neighbors",
+    assert percent_correct >= 0.98, (
+        "NN-descent did not get 99% " "accuracy on nearest neighbors"
     )
 
 
-def test_angular_nn_descent_neighbor_accuracy():
+def test_angular_nn_descent_neighbor_accuracy(nn_data, seed):
     knn_indices, _ = NNDescent(
-        nn_data, "cosine", {}, 10, random_state=np.random
+        nn_data, "cosine", {}, 10, random_state=np.random.RandomState(seed)
     )._neighbor_graph
 
     angular_data = normalize(nn_data, norm="l2")
@@ -70,14 +46,12 @@ def test_angular_nn_descent_neighbor_accuracy():
         num_correct += np.sum(np.in1d(true_indices[i], knn_indices[i]))
 
     percent_correct = num_correct / (nn_data.shape[0] * 10)
-    assert_greater_equal(
-        percent_correct,
-        0.98,
-        "NN-descent did not get 99% " "accuracy on nearest neighbors",
+    assert percent_correct >= 0.98, (
+        "NN-descent did not get 99% " "accuracy on nearest neighbors"
     )
 
 
-def test_sparse_nn_descent_neighbor_accuracy():
+def test_sparse_nn_descent_neighbor_accuracy(sparse_nn_data, seed):
     knn_indices, _ = NNDescent(
         sparse_nn_data, "euclidean", n_neighbors=20, random_state=None
     )._neighbor_graph
@@ -90,14 +64,12 @@ def test_sparse_nn_descent_neighbor_accuracy():
         num_correct += np.sum(np.in1d(true_indices[i], knn_indices[i]))
 
     percent_correct = num_correct / (sparse_nn_data.shape[0] * 10)
-    assert_greater_equal(
-        percent_correct,
-        0.85,
-        "Sparse NN-descent did not get 95% " "accuracy on nearest neighbors",
+    assert percent_correct >= 0.85, (
+        "Sparse NN-descent did not get 95% " "accuracy on nearest neighbors"
     )
 
 
-def test_sparse_angular_nn_descent_neighbor_accuracy():
+def test_sparse_angular_nn_descent_neighbor_accuracy(sparse_nn_data):
     knn_indices, _ = NNDescent(
         sparse_nn_data, "cosine", {}, 20, random_state=None
     )._neighbor_graph
@@ -111,14 +83,12 @@ def test_sparse_angular_nn_descent_neighbor_accuracy():
         num_correct += np.sum(np.in1d(true_indices[i], knn_indices[i]))
 
     percent_correct = num_correct / (sparse_nn_data.shape[0] * 10)
-    assert_greater_equal(
-        percent_correct,
-        0.85,
-        "Sparse angular NN-descent did not get 98% " "accuracy on nearest neighbors",
+    assert percent_correct >= 0.85, (
+        "Sparse angular NN-descent did not get 98% " "accuracy on nearest neighbors"
     )
 
 
-def test_nn_descent_query_accuracy():
+def test_nn_descent_query_accuracy(nn_data):
     nnd = NNDescent(nn_data[200:], "euclidean", n_neighbors=10, random_state=None)
     knn_indices, _ = nnd.query(nn_data[:200], k=10, epsilon=0.2)
 
@@ -130,14 +100,12 @@ def test_nn_descent_query_accuracy():
         num_correct += np.sum(np.in1d(true_indices[i], knn_indices[i]))
 
     percent_correct = num_correct / (true_indices.shape[0] * 10)
-    assert_greater_equal(
-        percent_correct,
-        0.95,
-        "NN-descent query did not get 95% " "accuracy on nearest neighbors",
+    assert percent_correct >= 0.95, (
+        "NN-descent query did not get 95% " "accuracy on nearest neighbors"
     )
 
 
-def test_nn_descent_query_accuracy_angular():
+def test_nn_descent_query_accuracy_angular(nn_data):
     nnd = NNDescent(nn_data[200:], "cosine", n_neighbors=30, random_state=None)
     knn_indices, _ = nnd.query(nn_data[:200], k=10, epsilon=0.32)
 
@@ -149,14 +117,12 @@ def test_nn_descent_query_accuracy_angular():
         num_correct += np.sum(np.in1d(true_indices[i], knn_indices[i]))
 
     percent_correct = num_correct / (true_indices.shape[0] * 10)
-    assert_greater_equal(
-        percent_correct,
-        0.95,
-        "NN-descent query did not get 95% " "accuracy on nearest neighbors",
+    assert percent_correct >= 0.95, (
+        "NN-descent query did not get 95% " "accuracy on nearest neighbors"
     )
 
 
-def test_sparse_nn_descent_query_accuracy():
+def test_sparse_nn_descent_query_accuracy(sparse_nn_data):
     nnd = NNDescent(
         sparse_nn_data[200:], "euclidean", n_neighbors=15, random_state=None
     )
@@ -170,14 +136,12 @@ def test_sparse_nn_descent_query_accuracy():
         num_correct += np.sum(np.in1d(true_indices[i], knn_indices[i]))
 
     percent_correct = num_correct / (true_indices.shape[0] * 10)
-    assert_greater_equal(
-        percent_correct,
-        0.95,
-        "Sparse NN-descent query did not get 95% " "accuracy on nearest neighbors",
+    assert percent_correct >= 0.95, (
+        "Sparse NN-descent query did not get 95% " "accuracy on nearest neighbors"
     )
 
 
-def test_sparse_nn_descent_query_accuracy_angular():
+def test_sparse_nn_descent_query_accuracy_angular(sparse_nn_data):
     nnd = NNDescent(sparse_nn_data[200:], "cosine", n_neighbors=50, random_state=None)
     knn_indices, _ = nnd.query(sparse_nn_data[:200], k=10, epsilon=0.36)
 
@@ -191,14 +155,12 @@ def test_sparse_nn_descent_query_accuracy_angular():
         num_correct += np.sum(np.in1d(true_indices[i], knn_indices[i]))
 
     percent_correct = num_correct / (true_indices.shape[0] * 10)
-    assert_greater_equal(
-        percent_correct,
-        0.95,
-        "Sparse NN-descent query did not get 95% " "accuracy on nearest neighbors",
+    assert percent_correct >= 0.95, (
+        "Sparse NN-descent query did not get 95% " "accuracy on nearest neighbors"
     )
 
 
-def test_transformer_equivalence():
+def test_transformer_equivalence(nn_data):
     N_NEIGHBORS = 15
     EPSILON = 0.15
     train = nn_data[:400]
@@ -225,7 +187,7 @@ def test_transformer_equivalence():
     assert np.allclose(Xt.data, dists_sorted.flat)
 
 
-def test_random_state_none():
+def test_random_state_none(nn_data, spatial_data):
     knn_indices, _ = NNDescent(
         nn_data, "euclidean", {}, 10, random_state=None
     )._neighbor_graph
@@ -238,10 +200,8 @@ def test_random_state_none():
         num_correct += np.sum(np.in1d(true_indices[i], knn_indices[i]))
 
     percent_correct = num_correct / (spatial_data.shape[0] * 10)
-    assert_greater_equal(
-        percent_correct,
-        0.99,
-        "NN-descent did not get 99% " "accuracy on nearest neighbors",
+    assert percent_correct >= 0.99, (
+        "NN-descent did not get 99% " "accuracy on nearest neighbors"
     )
 
 
@@ -265,42 +225,44 @@ def test_deterministic():
 # https://github.com/lmcinnes/umap/issues/99
 # graph_data used is a cut-down version of that provided by @scharron
 # It contains lots of all-zero vectors and some other duplicates
-def test_rp_trees_should_not_stack_overflow_with_duplicate_data():
-    this_dir = os.path.dirname(os.path.abspath(__file__))
-    data_path = os.path.join(this_dir, "test_data/cosine_hang.npy")
-    data = np.load(data_path)
+def test_rp_trees_should_not_stack_overflow_with_duplicate_data(seed, cosine_hang_data):
 
     n_neighbors = 10
     knn_indices, _ = NNDescent(
-        data, "cosine", {}, n_neighbors, random_state=np.random, n_trees=20
+        cosine_hang_data,
+        "cosine",
+        {},
+        n_neighbors,
+        random_state=np.random.RandomState(seed),
+        n_trees=20,
     )._neighbor_graph
 
-    for i in range(data.shape[0]):
-        assert_equal(
-            len(knn_indices[i]),
-            len(np.unique(knn_indices[i])),
-            "Duplicate graph_indices in knn graph",
-        )
+    for i in range(cosine_hang_data.shape[0]):
+        assert len(knn_indices[i]) == len(
+            np.unique(knn_indices[i])
+        ), "Duplicate graph_indices in knn graph"
 
 
-def test_deduplicated_data_behaves_normally():
-    this_dir = os.path.dirname(os.path.abspath(__file__))
-    data_path = os.path.join(this_dir, "test_data/cosine_hang.npy")
-    data = np.unique(np.load(data_path), axis=0)
+def test_deduplicated_data_behaves_normally(seed, cosine_hang_data):
+
+    data = np.unique(cosine_hang_data, axis=0)
     data = data[~np.all(data == 0, axis=1)]
     data = data[:1000]
 
     n_neighbors = 10
     knn_indices, _ = NNDescent(
-        data, "cosine", {}, n_neighbors, random_state=np.random, n_trees=20
+        data,
+        "cosine",
+        {},
+        n_neighbors,
+        random_state=np.random.RandomState(seed),
+        n_trees=20,
     )._neighbor_graph
 
     for i in range(data.shape[0]):
-        assert_equal(
-            len(knn_indices[i]),
-            len(np.unique(knn_indices[i])),
-            "Duplicate graph_indices in knn graph",
-        )
+        assert len(knn_indices[i]) == len(
+            np.unique(knn_indices[i])
+        ), "Duplicate graph_indices in knn graph"
 
     angular_data = normalize(data, norm="l2")
     tree = KDTree(angular_data)
@@ -311,14 +273,12 @@ def test_deduplicated_data_behaves_normally():
         num_correct += np.sum(np.in1d(true_indices[i], knn_indices[i]))
 
     proportion_correct = num_correct / (data.shape[0] * n_neighbors)
-    assert_greater_equal(
-        proportion_correct,
-        0.95,
-        "NN-descent did not get 95%" " accuracy on nearest neighbors",
+    assert proportion_correct >= 0.95, (
+        "NN-descent did not get 95%" " accuracy on nearest neighbors"
     )
 
 
-def test_output_when_verbose_is_true():
+def test_output_when_verbose_is_true(spatial_data, seed):
     out = io.StringIO()
     with redirect_stdout(out):
         _ = NNDescent(
@@ -326,17 +286,17 @@ def test_output_when_verbose_is_true():
             metric="euclidean",
             metric_kwds={},
             n_neighbors=4,
-            random_state=np.random,
+            random_state=np.random.RandomState(seed),
             n_trees=5,
             n_iters=2,
             verbose=True,
         )
     output = out.getvalue()
-    assert_true(re.match("^.*5 trees", output, re.DOTALL))
-    assert_true(re.match("^.*2 iterations", output, re.DOTALL))
+    assert re.match("^.*5 trees", output, re.DOTALL)
+    assert re.match("^.*2 iterations", output, re.DOTALL)
 
 
-def test_no_output_when_verbose_is_false():
+def test_no_output_when_verbose_is_false(spatial_data, seed):
     out = io.StringIO()
     with redirect_stdout(out):
         _ = NNDescent(
@@ -344,48 +304,48 @@ def test_no_output_when_verbose_is_false():
             metric="euclidean",
             metric_kwds={},
             n_neighbors=4,
-            random_state=np.random,
+            random_state=np.random.RandomState(seed),
             n_trees=5,
             n_iters=2,
             verbose=False,
         )
     output = out.getvalue().strip()
-    assert_equal(len(output), 0)
+    assert len(output) == 0
 
 
 # same as the previous two test, but this time using the PyNNDescentTransformer
 # interface
-def test_transformer_output_when_verbose_is_true():
+def test_transformer_output_when_verbose_is_true(spatial_data, seed):
     out = io.StringIO()
     with redirect_stdout(out):
         _ = PyNNDescentTransformer(
             n_neighbors=4,
             metric="euclidean",
             metric_kwds={},
-            random_state=np.random,
+            random_state=np.random.RandomState(seed),
             n_trees=5,
             n_iters=2,
             verbose=True,
         ).fit_transform(spatial_data)
     output = out.getvalue()
-    assert_true(re.match("^.*5 trees", output, re.DOTALL))
-    assert_true(re.match("^.*2 iterations", output, re.DOTALL))
+    assert re.match("^.*5 trees", output, re.DOTALL)
+    assert re.match("^.*2 iterations", output, re.DOTALL)
 
 
-def test_transformer_output_when_verbose_is_false():
+def test_transformer_output_when_verbose_is_false(spatial_data, seed):
     out = io.StringIO()
     with redirect_stdout(out):
         _ = PyNNDescentTransformer(
             n_neighbors=4,
             metric="standardised_euclidean",
             metric_kwds={"sigma": np.ones(spatial_data.shape[1])},
-            random_state=np.random,
+            random_state=np.random.RandomState(seed),
             n_trees=5,
             n_iters=2,
             verbose=False,
         ).fit_transform(spatial_data)
     output = out.getvalue().strip()
-    assert_equal(len(output), 0)
+    assert len(output) == 0
 
 
 def test_pickle_unpickle():
@@ -394,13 +354,7 @@ def test_pickle_unpickle():
     x1 = seed.normal(0, 100, (1000, 50))
     x2 = seed.normal(0, 100, (1000, 50))
 
-    index1 = NNDescent(
-        x1,
-        "euclidean",
-        {},
-        10,
-        random_state=None,
-    )
+    index1 = NNDescent(x1, "euclidean", {}, 10, random_state=None,)
     neighbors1, distances1 = index1.query(x2)
 
     pickle.dump(index1, open("test_tmp.pkl", "wb"))
@@ -419,14 +373,7 @@ def test_compressed_pickle_unpickle():
     x1 = seed.normal(0, 100, (1000, 50))
     x2 = seed.normal(0, 100, (1000, 50))
 
-    index1 = NNDescent(
-        x1,
-        "euclidean",
-        {},
-        10,
-        random_state=None,
-        compressed=True,
-    )
+    index1 = NNDescent(x1, "euclidean", {}, 10, random_state=None, compressed=True,)
     neighbors1, distances1 = index1.query(x2)
 
     pickle.dump(index1, open("test_tmp.pkl", "wb"))
@@ -464,13 +411,7 @@ def test_joblib_dump():
     x1 = seed.normal(0, 100, (1000, 50))
     x2 = seed.normal(0, 100, (1000, 50))
 
-    index1 = NNDescent(
-        x1,
-        "euclidean",
-        {},
-        10,
-        random_state=None,
-    )
+    index1 = NNDescent(x1, "euclidean", {}, 10, random_state=None,)
     neighbors1, distances1 = index1.query(x2)
 
     joblib.dump(index1, "test_tmp.dump")

--- a/pynndescent/tests/test_rank.py
+++ b/pynndescent/tests/test_rank.py
@@ -1,5 +1,6 @@
+import pytest
 import numpy as np
-from numpy.testing import assert_equal, assert_array_equal
+from numpy.testing import assert_array_equal
 
 from pynndescent.distances import rankdata
 
@@ -94,51 +95,132 @@ def test_big_tie():
         assert_array_equal(r, expected_rank * data, "test failed with n=%d" % n)
 
 
-# fmt: off
-_cases = (
-    # values, method, expected
-    (np.array([], np.float64), 'average', np.array([], np.float64)),
-    (np.array([], np.float64), 'min', np.array([], np.float64)),
-    (np.array([], np.float64), 'max', np.array([], np.float64)),
-    (np.array([], np.float64), 'dense', np.array([], np.float64)),
-    (np.array([], np.float64), 'ordinal', np.array([], np.float64)),
-    #
-    (np.array([100], np.float64), 'average', np.array([1.0], np.float64)),
-    (np.array([100], np.float64), 'min', np.array([1.0], np.float64)),
-    (np.array([100], np.float64), 'max', np.array([1.0], np.float64)),
-    (np.array([100], np.float64), 'dense', np.array([1.0], np.float64)),
-    (np.array([100], np.float64), 'ordinal', np.array([1.0], np.float64)),
-    # #
-    (np.array([100, 100, 100], np.float64), 'average', np.array([2.0, 2.0, 2.0], np.float64)),
-    (np.array([100, 100, 100], np.float64), 'min', np.array([1.0, 1.0, 1.0], np.float64)),
-    (np.array([100, 100, 100], np.float64), 'max', np.array([3.0, 3.0, 3.0], np.float64)),
-    (np.array([100, 100, 100], np.float64), 'dense', np.array([1.0, 1.0, 1.0], np.float64)),
-    (np.array([100, 100, 100], np.float64), 'ordinal', np.array([1.0, 2.0, 3.0], np.float64)),
-    #
-    (np.array([100, 300, 200], np.float64), 'average', np.array([1.0, 3.0, 2.0], np.float64)),
-    (np.array([100, 300, 200], np.float64), 'min', np.array([1.0, 3.0, 2.0], np.float64)),
-    (np.array([100, 300, 200], np.float64), 'max', np.array([1.0, 3.0, 2.0], np.float64)),
-    (np.array([100, 300, 200], np.float64), 'dense', np.array([1.0, 3.0, 2.0], np.float64)),
-    (np.array([100, 300, 200], np.float64), 'ordinal', np.array([1.0, 3.0, 2.0], np.float64)),
-    #
-    (np.array([100, 200, 300, 200], np.float64), 'average', np.array([1.0, 2.5, 4.0, 2.5], np.float64)),
-    (np.array([100, 200, 300, 200], np.float64), 'min', np.array([1.0, 2.0, 4.0, 2.0], np.float64)),
-    (np.array([100, 200, 300, 200], np.float64), 'max', np.array([1.0, 3.0, 4.0, 3.0], np.float64)),
-    (np.array([100, 200, 300, 200], np.float64), 'dense', np.array([1.0, 2.0, 3.0, 2.0], np.float64)),
-    (np.array([100, 200, 300, 200], np.float64), 'ordinal', np.array([1.0, 2.0, 4.0, 3.0], np.float64)),
-    #
-    (np.array([100, 200, 300, 200, 100], np.float64), 'average', np.array([1.5, 3.5, 5.0, 3.5, 1.5], np.float64)),
-    (np.array([100, 200, 300, 200, 100], np.float64), 'min', np.array([1.0, 3.0, 5.0, 3.0, 1.0], np.float64)),
-    (np.array([100, 200, 300, 200, 100], np.float64), 'max', np.array([2.0, 4.0, 5.0, 4.0, 2.0], np.float64)),
-    (np.array([100, 200, 300, 200, 100], np.float64), 'dense', np.array([1.0, 2.0, 3.0, 2.0, 1.0], np.float64)),
-    (np.array([100, 200, 300, 200, 100], np.float64), 'ordinal', np.array([1.0, 3.0, 5.0, 4.0, 2.0], np.float64)),
-    #
-    (np.array([10] * 30, np.float64), 'ordinal', np.arange(1.0, 31.0, dtype=np.float64)),
+@pytest.mark.parametrize(
+    "values,method,expected",
+    [  # values, method, expected
+        (np.array([], np.float64), "average", np.array([], np.float64)),
+        (np.array([], np.float64), "min", np.array([], np.float64)),
+        (np.array([], np.float64), "max", np.array([], np.float64)),
+        (np.array([], np.float64), "dense", np.array([], np.float64)),
+        (np.array([], np.float64), "ordinal", np.array([], np.float64)),
+        #
+        (np.array([100], np.float64), "average", np.array([1.0], np.float64)),
+        (np.array([100], np.float64), "min", np.array([1.0], np.float64)),
+        (np.array([100], np.float64), "max", np.array([1.0], np.float64)),
+        (np.array([100], np.float64), "dense", np.array([1.0], np.float64)),
+        (np.array([100], np.float64), "ordinal", np.array([1.0], np.float64)),
+        # #
+        (
+            np.array([100, 100, 100], np.float64),
+            "average",
+            np.array([2.0, 2.0, 2.0], np.float64),
+        ),
+        (
+            np.array([100, 100, 100], np.float64),
+            "min",
+            np.array([1.0, 1.0, 1.0], np.float64),
+        ),
+        (
+            np.array([100, 100, 100], np.float64),
+            "max",
+            np.array([3.0, 3.0, 3.0], np.float64),
+        ),
+        (
+            np.array([100, 100, 100], np.float64),
+            "dense",
+            np.array([1.0, 1.0, 1.0], np.float64),
+        ),
+        (
+            np.array([100, 100, 100], np.float64),
+            "ordinal",
+            np.array([1.0, 2.0, 3.0], np.float64),
+        ),
+        #
+        (
+            np.array([100, 300, 200], np.float64),
+            "average",
+            np.array([1.0, 3.0, 2.0], np.float64),
+        ),
+        (
+            np.array([100, 300, 200], np.float64),
+            "min",
+            np.array([1.0, 3.0, 2.0], np.float64),
+        ),
+        (
+            np.array([100, 300, 200], np.float64),
+            "max",
+            np.array([1.0, 3.0, 2.0], np.float64),
+        ),
+        (
+            np.array([100, 300, 200], np.float64),
+            "dense",
+            np.array([1.0, 3.0, 2.0], np.float64),
+        ),
+        (
+            np.array([100, 300, 200], np.float64),
+            "ordinal",
+            np.array([1.0, 3.0, 2.0], np.float64),
+        ),
+        #
+        (
+            np.array([100, 200, 300, 200], np.float64),
+            "average",
+            np.array([1.0, 2.5, 4.0, 2.5], np.float64),
+        ),
+        (
+            np.array([100, 200, 300, 200], np.float64),
+            "min",
+            np.array([1.0, 2.0, 4.0, 2.0], np.float64),
+        ),
+        (
+            np.array([100, 200, 300, 200], np.float64),
+            "max",
+            np.array([1.0, 3.0, 4.0, 3.0], np.float64),
+        ),
+        (
+            np.array([100, 200, 300, 200], np.float64),
+            "dense",
+            np.array([1.0, 2.0, 3.0, 2.0], np.float64),
+        ),
+        (
+            np.array([100, 200, 300, 200], np.float64),
+            "ordinal",
+            np.array([1.0, 2.0, 4.0, 3.0], np.float64),
+        ),
+        #
+        (
+            np.array([100, 200, 300, 200, 100], np.float64),
+            "average",
+            np.array([1.5, 3.5, 5.0, 3.5, 1.5], np.float64),
+        ),
+        (
+            np.array([100, 200, 300, 200, 100], np.float64),
+            "min",
+            np.array([1.0, 3.0, 5.0, 3.0, 1.0], np.float64),
+        ),
+        (
+            np.array([100, 200, 300, 200, 100], np.float64),
+            "max",
+            np.array([2.0, 4.0, 5.0, 4.0, 2.0], np.float64),
+        ),
+        (
+            np.array([100, 200, 300, 200, 100], np.float64),
+            "dense",
+            np.array([1.0, 2.0, 3.0, 2.0, 1.0], np.float64),
+        ),
+        (
+            np.array([100, 200, 300, 200, 100], np.float64),
+            "ordinal",
+            np.array([1.0, 3.0, 5.0, 4.0, 2.0], np.float64),
+        ),
+        #
+        (
+            np.array([10] * 30, np.float64),
+            "ordinal",
+            np.arange(1.0, 31.0, dtype=np.float64),
+        ),
+    ],
 )
-# fmt: on
-
-
-def test_cases():
-    for values, method, expected in _cases:
-        r = rankdata(values, method=method)
-        assert_array_equal(r, expected)
+def test_cases(values, method, expected):
+    r = rankdata(values, method=method)
+    assert_array_equal(r, expected)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 joblib
+numpy>=1.17
 scikit-learn>=0.18
 scipy>=1.0
 numba>=0.51.2


### PR DESCRIPTION
As promised in [#578](https://github.com/lmcinnes/umap/pull/578#issuecomment-777023951), this PR migrates and rewrites `pynndescent` test suite to make it compatible with `pytest`.

In addition: 

- Python 3.8 pipelines have been added in CI
- CI scripts should be updated accordingly to use Pytest (with and without coverage support).

*EDIT*: Bear with me while I do test and fix CI scripts :)