### PR TITLE
Fix incorrect execution path when pickling rp_trees for sparse data.

### DIFF
--- a/pynndescent/pynndescent_.py
+++ b/pynndescent/pynndescent_.py
@@ -932,7 +932,10 @@ class NNDescent(object):
         if not hasattr(self, "_search_graph"):
             self._init_search_graph()
         if not hasattr(self, "_search_function"):
-            self._init_search_function()
+            if self._is_sparse:
+                self._init_sparse_search_function()
+            else:
+                self._init_search_function()
         result = self.__dict__.copy()
         if hasattr(self, "_rp_forest"):
             del result["_rp_forest"]


### PR DESCRIPTION
I'm getting the following error while pickling a fitted UMAP object. While this happening using umap it looks like the problem is in pynndescent

```
Traceback (most recent call last):
  File "pipeline.py", line 236, in <module>
    fire.Fire()
  File "/usr/local/lib/python3.8/site-packages/fire/core.py", line 141, in Fire
    component_trace = _Fire(component, args, parsed_flag_args, context, name)
  File "/usr/local/lib/python3.8/site-packages/fire/core.py", line 466, in _Fire
    component, remaining_args = _CallAndUpdateTrace(
  File "/usr/local/lib/python3.8/site-packages/fire/core.py", line 681, in _CallAndUpdateTrace
    component = fn(*varargs, **kwargs)
  File "pipeline.py", line 72, in process
    joblib.dump(doc_to_vec_transform, f'/doc2vec.pk.gz.{site}')
  File "/usr/local/lib/python3.8/site-packages/joblib/numpy_pickle.py", line 480, in dump
    NumpyPickler(f, protocol=protocol).dump(value)
  File "/usr/local/lib/python3.8/pickle.py", line 487, in dump
    self.save(obj)
  File "/usr/local/lib/python3.8/site-packages/joblib/numpy_pickle.py", line 282, in save
    return Pickler.save(self, obj)
  File "/usr/local/lib/python3.8/pickle.py", line 603, in save
    self.save_reduce(obj=obj, *rv)
  File "/usr/local/lib/python3.8/pickle.py", line 717, in save_reduce
    save(state)
  File "/usr/local/lib/python3.8/site-packages/joblib/numpy_pickle.py", line 282, in save
    return Pickler.save(self, obj)
  File "/usr/local/lib/python3.8/pickle.py", line 560, in save
    f(self, obj)  # Call unbound method with explicit self
  File "/usr/local/lib/python3.8/pickle.py", line 971, in save_dict
    self._batch_setitems(obj.items())
  File "/usr/local/lib/python3.8/pickle.py", line 997, in _batch_setitems
    save(v)
  File "/usr/local/lib/python3.8/site-packages/joblib/numpy_pickle.py", line 282, in save
    return Pickler.save(self, obj)
  File "/usr/local/lib/python3.8/pickle.py", line 578, in save
    rv = reduce(self.proto)
  File "/usr/local/lib/python3.8/site-packages/pynndescent/pynndescent_.py", line 935, in __getstate__
    self._init_search_function()
  File "/usr/local/lib/python3.8/site-packages/pynndescent/pynndescent_.py", line 1178, in _init_search_function
    def tree_search_closure(point, rng_state):
  File "/usr/local/lib/python3.8/site-packages/numba/core/decorators.py", line 221, in wrapper
    disp.compile(sig)
  File "/usr/local/lib/python3.8/site-packages/numba/core/compiler_lock.py", line 32, in _acquire_compile_lock
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/numba/core/dispatcher.py", line 857, in compile
    cres = self._compiler.compile(args, return_type)
  File "/usr/local/lib/python3.8/site-packages/numba/core/dispatcher.py", line 81, in compile
    raise retval
  File "/usr/local/lib/python3.8/site-packages/numba/core/dispatcher.py", line 91, in _compile_cached
    retval = self._compile_core(args, return_type)
  File "/usr/local/lib/python3.8/site-packages/numba/core/dispatcher.py", line 104, in _compile_core
    cres = compiler.compile_extra(self.targetdescr.typing_context,
  File "/usr/local/lib/python3.8/site-packages/numba/core/compiler.py", line 602, in compile_extra
    return pipeline.compile_extra(func)
  File "/usr/local/lib/python3.8/site-packages/numba/core/compiler.py", line 352, in compile_extra
    return self._compile_bytecode()
  File "/usr/local/lib/python3.8/site-packages/numba/core/compiler.py", line 414, in _compile_bytecode
    return self._compile_core()
  File "/usr/local/lib/python3.8/site-packages/numba/core/compiler.py", line 394, in _compile_core
    raise e
  File "/usr/local/lib/python3.8/site-packages/numba/core/compiler.py", line 385, in _compile_core
    pm.run(self.state)
  File "/usr/local/lib/python3.8/site-packages/numba/core/compiler_machinery.py", line 339, in run
    raise patched_exception
  File "/usr/local/lib/python3.8/site-packages/numba/core/compiler_machinery.py", line 330, in run
    self._runPass(idx, pass_inst, state)
  File "/usr/local/lib/python3.8/site-packages/numba/core/compiler_lock.py", line 32, in _acquire_compile_lock
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/numba/core/compiler_machinery.py", line 289, in _runPass
    mutated |= check(pss.run_pass, internal_state)
  File "/usr/local/lib/python3.8/site-packages/numba/core/compiler_machinery.py", line 262, in check
    mangled = func(compiler_state)
  File "/usr/local/lib/python3.8/site-packages/numba/core/typed_passes.py", line 94, in run_pass
    typemap, return_type, calltypes = type_inference_stage(
  File "/usr/local/lib/python3.8/site-packages/numba/core/typed_passes.py", line 72, in type_inference_stage
    infer.propagate(raise_errors=raise_errors)
  File "/usr/local/lib/python3.8/site-packages/numba/core/typeinfer.py", line 1071, in propagate
    raise errors[0]
numba.core.errors.TypingError: Failed in nopython mode pipeline (step: nopython frontend)
Invalid use of type(CPUDispatcher(<function select_side at 0x7f17395dbb80>)) with parameters (readonly array(float32, 2d, C), float32, readonly array(float32, 1d, C), array(int64, 1d, C))
Known signatures:
 * (array(float32, 1d, C), float32, array(float32, 1d, C), array(int64, 1d, C)) -> bool
 * (readonly array(float32, 1d, C), float32, readonly array(float32, 1d, C), array(int64, 1d, C)) -> bool
During: resolving callee type: type(CPUDispatcher(<function select_side at 0x7f17395dbb80>))
During: typing of call at /usr/local/lib/python3.8/site-packages/pynndescent/pynndescent_.py (1181)


File "../../../../../usr/local/lib/python3.8/site-packages/pynndescent/pynndescent_.py", line 1181:
        def tree_search_closure(point, rng_state):
            <source elided>
            while tree_children[node, 0] > 0:
                side = select_side(
                ^

```

Things seem to go wrong here:
```
  File "/usr/local/lib/python3.8/site-packages/pynndescent/pynndescent_.py", line 935, in __getstate__
    self._init_search_function()
```

as it should be using:
`    self._init_sparse_search_function()`

When it uses _init_search_function() it ends up trying to use select_side (instead of sparse_select_side) which can't deal with the sparse_hyperplane_type:
```
dense_hyperplane_type = numba.float32[::1]
sparse_hyperplane_type = numba.float64[:, ::1]
```

Hence the signature missmatch:
(readonly array(float32, 2d, C), float32, readonly array(float32, 1d, C), array(int64, 1d, C))
Expected: (readonly array(float32, 1d, C), float32, readonly array(float32, 1d, C), array(int64, 1d, C))

The hyperplane array being 2d instead of 1d in the sparse case.

I've just added the if statement to test for sparse that I see elsewhere in the code:

```
            if self._is_sparse:
                self._init_sparse_search_function()
            else:
                self._init_search_function()
```

So that it will choose a code path designed for sparse data.

This seems to fix the problem with pickling and unpickling.