### PR TITLE
Fix incorrect execution path when unpickling rp_trees for sparse data.

### DIFF
--- a/pynndescent/pynndescent_.py
+++ b/pynndescent/pynndescent_.py
@@ -932,7 +932,10 @@ class NNDescent(object):
         if not hasattr(self, "_search_graph"):
             self._init_search_graph()
         if not hasattr(self, "_search_function"):
-            self._init_search_function()
+            if self._is_sparse:
+                self._init_sparse_search_function()
+            else:
+                self._init_search_function()
         result = self.__dict__.copy()
         if hasattr(self, "_rp_forest"):
             del result["_rp_forest"]
@@ -946,7 +949,10 @@ class NNDescent(object):
         self._search_forest = tuple(
             [renumbaify_tree(tree) for tree in d["_search_forest"]]
         )
-        self._init_search_function()
+        if self._is_sparse:
+            self._init_sparse_search_function()
+        else:
+            self._init_search_function()
 
     def _init_search_graph(self):
 


### PR DESCRIPTION
This is just the other half I missed adding to #118

To fix this kind of exception when unpickling for sparse data:
```
:/setstate
  File "/usr/local/lib/python3.8/site-packages/numba/core/compiler_machinery.py", line 289, in _runPass
    mutated |= check(pss.run_pass, internal_state)
  File "/usr/local/lib/python3.8/site-packages/numba/core/compiler_machinery.py", line 262, in check
    mangled = func(compiler_state)
  File "/usr/local/lib/python3.8/site-packages/numba/core/typed_passes.py", line 94, in run_pass
    typemap, return_type, calltypes = type_inference_stage(
  File "/usr/local/lib/python3.8/site-packages/numba/core/typed_passes.py", line 72, in type_inference_stage
    infer.propagate(raise_errors=raise_errors)
  File "/usr/local/lib/python3.8/site-packages/numba/core/typeinfer.py", line 1071, in propagate
    raise errors[0]
numba.core.errors.TypingError: Failed in nopython mode pipeline (step: nopython frontend)
Invalid use of type(CPUDispatcher(<function select_side at 0x7fd8a71481f0>)) with parameters (readonly array(float32, 2d, C), float32, readonly array(float32, 1d, C), array(int64, 1d, C))
Known signatures:
 * (array(float32, 1d, C), float32, array(float32, 1d, C), array(int64, 1d, C)) -> bool
 * (readonly array(float32, 1d, C), float32, readonly array(float32, 1d, C), array(int64, 1d, C)) -> bool
During: resolving callee type: type(CPUDispatcher(<function select_side at 0x7fd8a71481f0>))
During: typing of call at /usr/local/lib/python3.8/site-packages/pynndescent/pynndescent_.py (1184)


File "../../../../../usr/local/lib/python3.8/site-packages/pynndescent/pynndescent_.py", line 1184:
        def tree_search_closure(point, rng_state):
            <source elided>
            while tree_children[node, 0] > 0:
                side = select_side(
                ^
```

 