### PR TITLE
Replace pkg_resources with importlib.metadata

### DIFF
--- a/pynndescent/__init__.py
+++ b/pynndescent/__init__.py
@@ -1,6 +1,13 @@
-import pkg_resources
+import sys
+
 import numba
+
 from .pynndescent_ import NNDescent, PyNNDescentTransformer
+
+if sys.version_info[:2] >= (3, 8):
+    import importlib.metadata as importlib_metadata
+else:
+    import importlib_metadata
 
 # Workaround: https://github.com/numba/numba/issues/3341
 if numba.config.THREADING_LAYER == "omp":
@@ -12,4 +19,4 @@ if numba.config.THREADING_LAYER == "omp":
         # might be a missing symbol due to e.g. tbb libraries missing
         numba.config.THREADING_LAYER = "workqueue"
 
-__version__ = pkg_resources.get_distribution("pynndescent").version
+__version__ = importlib_metadata.version("pynndescent")

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ configuration = {
         "numba >= 0.51.2",
         "llvmlite >= 0.30",
         "joblib >= 0.11",
+        'importlib-metadata >= 4.8.1; python_version < "3.8"',
     ],
     "ext_modules": [],
     "cmdclass": {},


### PR DESCRIPTION
pkg_resources was causing errors when using our package on google colab due to its internal caching (https://github.com/sacdallago/bio_embeddings/issues/160, https://github.com/sacdallago/bio_embeddings/issues/123), so I've replaced it with importlib.metadata. I've done the same change before for huggingface/transformers (ttps://github.com/huggingface/transformers/issues/10964). Also note that pkg_resources is deprecated in favor of importlib.metadata (https://setuptools.readthedocs.io/en/latest/pkg_resources.html). For python versions older than 3.8, I'm using the official importlib-metadata backport.
