### PR TITLE
Add deprecation notice to n_search_trees parameter docstring

### DIFF
--- a/pynndescent/pynndescent_.py
+++ b/pynndescent/pynndescent_.py
@@ -573,6 +573,12 @@ class NNDescent(object):
         that no edges get removed, and larger values result in significantly more
         aggressive edge removal. A value of 1.0 will prune all edges that it can.
 
+    n_search_trees: int (optional, default=1)
+        The number of random projection trees to use in initializing searching or
+        querying.
+
+        .. deprecated:: 0.5.5
+
     tree_init: bool (optional, default=True)
         Whether to use random projection trees for initialization.
 
@@ -1732,9 +1738,11 @@ class PyNNDescentTransformer(BaseEstimator, TransformerMixin):
         that no edges get removed, and larger values result in significantly more
         aggressive edge removal. A value of 1.0 will prune all edges that it can.
 
-    n_search_trees: float (optional, default=1)
+    n_search_trees: int (optional, default=1)
         The number of random projection trees to use in initializing searching or
         querying.
+
+        .. deprecated:: 0.5.5
 
     search_epsilon: float (optional, default=0.1)
         When searching for nearest neighbors of a query point this values

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def readme():
 
 configuration = {
     "name": "pynndescent",
-    "version": "0.5.4",
+    "version": "0.5.5",
     "description": "Nearest Neighbor Descent",
     "long_description": readme(),
     "classifiers": [


### PR DESCRIPTION
As discussed in #139. This PR:

* Adds a deprecation notice to the `n_search_trees` parameter in `PyNNDescentTransformer` and `NNDescent` docstring. The latter did not actually mention the parameter, so I added it for consistency's sake. I'm sure users will be overjoyed to discover the documentation of a parameter that they should no longer use. You're welcome.
* Increments the (patch release) version in `setup.py` to `0.5.5` to avoid confusion over which version the deprecation is occurring in.

I copied the docstring formatting from docstring in Pandas. The sphinx HTML output seems perfectly reasonable.