### PR TITLE
Fix "'NNDescent' object has no attribute '_vertex_order'" crash in NNDescent.update

### DIFF
--- a/pynndescent/pynndescent_.py
+++ b/pynndescent/pynndescent_.py
@@ -628,7 +628,7 @@ class NNDescent(object):
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors.
 
-    compressed: bool (optional, default=False)
+    compressed: bool (optional, default=True)
         Whether to prune out data not needed for searching the index. This will
         result in a significantly smaller index, particularly useful for saving,
         but will remove information that might otherwise be useful.


### PR DESCRIPTION
Part of the fix for https://github.com/lmcinnes/umap/issues/790

Check that the search graph has been initialized in `NNDescent.update` to prevent reference to a nonexistent `self._vertex_order`. This same check is done in the other methods that reference the same property.

Also fixes an error in the `NNDescent` docstring that stated the wrong default value for `compressed`. This causes problems for `UMAP.update` because UMAP assumes `compressed=False` still.