### PR TITLE
fix docstring for NNDescent

### DIFF
--- a/pynndescent/pynndescent_.py
+++ b/pynndescent/pynndescent_.py
@@ -496,7 +496,7 @@ def resort_tree_indices(tree, tree_order):
     return new_tree
 
 
-class NNDescent(object):
+class NNDescent:
     """NNDescent for fast approximate nearest neighbor queries. NNDescent is
     very flexible and supports a wide variety of distances, including
     non-metric distances. NNDescent also scales well against high dimensional
@@ -505,7 +505,7 @@ class NNDescent(object):
 
     Parameters
     ----------
-    data: array os shape (n_samples, n_features)
+    data: array of shape (n_samples, n_features)
         The training graph_data set to find nearest neighbors in.
 
     metric: string or callable (optional, default='euclidean')
@@ -596,14 +596,11 @@ class NNDescent(object):
         The``'alternative'`` algorithm has been deprecated and is no longer
         available.
 
-    low_memory: boolean (optional, default=False)
+    low_memory: boolean (optional, default=True)
         Whether to use a lower memory, but more computationally expensive
-        approach to index construction. This defaults to false as for most
-        cases it speeds index construction, but if you are having issues
-        with excessive memory use for your dataset consider setting this
-        to True.
+        approach to index construction.
 
-    max_candidates: int (optional, default=20)
+    max_candidates: int (optional, default=None)
         Internally each "self-join" keeps a maximum number of candidates (
         nearest neighbors and reverse nearest neighbors) to be considered.
         This value controls this aspect of the algorithm. Larger values will
@@ -629,7 +626,7 @@ class NNDescent(object):
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors.
 
-    compressed: bool (optional, default=True)
+    compressed: bool (optional, default=False)
         Whether to prune out data not needed for searching the index. This will
         result in a significantly smaller index, particularly useful for saving,
         but will remove information that might otherwise be useful.


### PR DESCRIPTION
(this PR has nothing to do with dask, that's just what I named my fork)

Since I [tweeted](https://twitter.com/james_t_webber/status/1476962551384711168) about it I figured I should fix the problem with the docs. This changes the docstrings so that they match the actual defaults.

The only case where this is a major change is the description of the `low_memory` option. The previous docs suggested it was slower, but it often isn't. Also, I don't think the high memory algorithm has been getting tested thoroughly and might have some regressions (e.g. I found https://github.com/lmcinnes/pynndescent/issues/135 last summer). It might be a good idea to add a warning to that effect.

As another very minor change here, I removed the class inheritance from `object`, which is unnecessary in python 3 and not considered proper style IIRC.

I had thought that Sphinx supported the automatic documentation for default values out of the box, but I guess that's an extension. That would make this type of thing easier to maintain as there would only be one location to change.