### PR TITLE
Update sparse distances

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 dist: xenial
 sudo: false
 python:
-  - "3.6"
   - "3.7"
   - "3.8"
 env:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,13 +2,12 @@ build: "off"
 
 environment:
   matrix:
-    - PYTHON_VERSION: "3.6"
-      MINICONDA: C:\Miniconda36-x64
     - PYTHON_VERSION: "3.7"
       MINICONDA: C:\Miniconda3-x64
     - PYTHON_VERSION: "3.8"
       MINICONDA: C:\Miniconda3-x64
-
+    - PYTHON_VERSION: "3.9"
+      MINICONDA: C:\Miniconda3-x64
 init:
   - "ECHO %PYTHON_VERSION% %MINICONDA%"
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,9 +28,6 @@ strategy:
     linux_py39:
       imageName: 'ubuntu-latest'
       python.version: '3.9'
-    linux_py310:
-      imageName: 'ubuntu-latest'
-      python.version: '3.10'
     windows_py37:
       imageName: 'windows-latest'
       python.version: '3.7'
@@ -40,9 +37,6 @@ strategy:
     windows_py39:
       imageName: 'windows-latest'
       python.version: '3.9'
-    windows_py310:
-      imageName: 'windows-latest'
-      python.version: '3.10'
 
 pool:
   vmImage: $(imageName)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,15 +10,39 @@ trigger:
 # https://github.com/Microsoft/azure-pipelines-yaml/issues/20
 strategy:
   matrix:
-    mac10.14_py36:
-      imageName: 'macOS-10.14'
-      python.version: '3.6'
-    mac10.14_py37:
-      imageName: 'macOS-10.14'
+    mac_py37:
+      imageName: 'macOS-latest'
       python.version: '3.7'
-    mac10.14_py38:
-      imageName: 'macOS-10.14'
+    mac_py38:
+      imageName: 'macOS-latest'
       python.version: '3.8'
+    mac_py39:
+      imageName: 'macOS-latest'
+      python.version: '3.9'
+    linux_py37:
+      imageName: 'ubuntu-latest'
+      python.version: '3.7'
+    linux_py38:
+      imageName: 'ubuntu-latest'
+      python.version: '3.8'
+    linux_py39:
+      imageName: 'ubuntu-latest'
+      python.version: '3.9'
+    linux_py310:
+      imageName: 'ubuntu-latest'
+      python.version: '3.10'
+    windows_py37:
+      imageName: 'windows-latest'
+      python.version: '3.7'
+    sindows_py38:
+      imageName: 'windows-latest'
+      python.version: '3.8'
+    windows_py39:
+      imageName: 'windows-latest'
+      python.version: '3.9'
+    windows_py310:
+      imageName: 'windows-latest'
+      python.version: '3.10'
 
 pool:
   vmImage: $(imageName)

--- a/pynndescent/pynndescent_.py
+++ b/pynndescent/pynndescent_.py
@@ -745,7 +745,7 @@ class NNDescent:
             "dot",
             "correlation",
             "dice",
-            "jaccard",
+            # "jaccard",
             "hellinger",
             "hamming",
         ):

--- a/pynndescent/pynndescent_.py
+++ b/pynndescent/pynndescent_.py
@@ -745,7 +745,7 @@ class NNDescent:
             "dot",
             "correlation",
             "dice",
-            # "jaccard",
+            "jaccard",
             "hellinger",
             "hamming",
         ):

--- a/pynndescent/rp_trees.py
+++ b/pynndescent/rp_trees.py
@@ -8,7 +8,7 @@ import numpy as np
 import numba
 import scipy.sparse
 
-from pynndescent.sparse import sparse_mul, sparse_diff, sparse_sum, arr_intersect
+from pynndescent.sparse import sparse_mul, sparse_diff, sparse_sum, arr_intersect, sparse_dot_product
 from pynndescent.utils import tau_rand_int, norm
 import joblib
 
@@ -908,10 +908,7 @@ def sparse_select_side(hyperplane, offset, point_inds, point_data, rng_state):
     hyperplane_inds = hyperplane[0, :hyperplane_size].astype(np.int32)
     hyperplane_data = hyperplane[1, :hyperplane_size]
 
-    _, aux_data = sparse_mul(hyperplane_inds, hyperplane_data, point_inds, point_data)
-
-    for val in aux_data:
-        margin += val
+    margin += sparse_dot_product(hyperplane_inds, hyperplane_data, point_inds, point_data)
 
     if abs(margin) < EPS:
         side = tau_rand_int(rng_state) % 2

--- a/pynndescent/sparse.py
+++ b/pynndescent/sparse.py
@@ -443,6 +443,8 @@ def sparse_alternative_jaccard(ind1, data1, ind2, data2):
 
     if num_non_zero == 0:
         return 0.0
+    elif num_equal == 0:
+        return FLOAT32_MAX
     else:
         # return -np.log2(num_equal / num_non_zero)
         return (num_non_zero - num_equal) / num_equal
@@ -456,8 +458,8 @@ def correct_alternative_jaccard(v):
 
 @numba.njit()
 def sparse_matching(ind1, data1, ind2, data2, n_features):
-    num_equal = fast_intersection_size(ind1, ind2)
-    num_non_zero = ind1.shape[0] + ind2.shape[0] - num_equal
+    num_true_true = fast_intersection_size(ind1, ind2)
+    num_non_zero = ind1.shape[0] + ind2.shape[0] - num_true_true
     num_not_equal = num_non_zero - num_true_true
 
     return float(num_not_equal) / n_features

--- a/pynndescent/sparse.py
+++ b/pynndescent/sparse.py
@@ -68,6 +68,9 @@ def arr_intersect(ar1, ar2):
     }
 )
 def fast_intersection_size(ar1, ar2):
+    if ar1.shape[0] == 0 or ar2.shape[0] == 0:
+        return 0
+
     # NOTE: We assume arrays are sorted; if they are not this will break
     i1 = 0
     i2 = 0

--- a/pynndescent/sparse.py
+++ b/pynndescent/sparse.py
@@ -58,8 +58,8 @@ def arr_intersect(ar1, ar2):
     [
         "i4(i4[:],i4[:])",
         numba.types.int32(
-            numba.types.Array(numba.types.int32, 1, readonly=True),
-            numba.types.Array(numba.types.int32, 1, readonly=True),
+            numba.types.Array(numba.types.int32, 1, "C", readonly=True),
+            numba.types.Array(numba.types.int32, 1, "C", readonly=True),
         ),
     ],
     locals={

--- a/pynndescent/sparse.py
+++ b/pynndescent/sparse.py
@@ -71,21 +71,36 @@ def fast_intersection_size(ar1, ar2):
     # NOTE: We assume arrays are sorted; if they are not this will break
     i1 = 0
     i2 = 0
+    limit1 = ar1.shape[0] - 1
+    limit2 = ar2.shape[0] - 1
+    j1 = ar1[i1]
+    j2 = ar2[i2]
 
     result = 0
 
-    while i1 < ar1.shape[0] and i2 < ar2.shape[0]:
-        j1 = ar1[i1]
-        j2 = ar2[i2]
-
+    while True:
         if j1 == j2:
             result += 1
+            if i1 < limit1:
+                i1 += 1
+                j1 = ar1[i1]
+            else:
+                break
+
+            if i2 < limit2:
+                i2 += 1
+                j2 = ar2[i2]
+            else:
+                break
+
+        elif j1 < j2 and i1 < limit1:
             i1 += 1
+            j1 = ar1[i1]
+        elif j2 < j1 and i2 < limit2:
             i2 += 1
-        elif j1 < j2:
-            i1 += 1
+            j2 = ar2[i2]
         else:
-            i2 += 1
+            break
 
     return result
 
@@ -446,14 +461,14 @@ def sparse_alternative_jaccard(ind1, data1, ind2, data2):
     elif num_equal == 0:
         return FLOAT32_MAX
     else:
-        # return -np.log2(num_equal / num_non_zero)
-        return (num_non_zero - num_equal) / num_equal
+        return -np.log2(num_equal / num_non_zero)
+        # return (num_non_zero - num_equal) / num_equal
 
 
 @numba.vectorize(fastmath=True)
 def correct_alternative_jaccard(v):
-    # return 1.0 - pow(2.0, -v)
-    return v / (v + 1)
+    return 1.0 - pow(2.0, -v)
+    # return v / (v + 1)
 
 
 @numba.njit()

--- a/pynndescent/sparse.py
+++ b/pynndescent/sparse.py
@@ -252,12 +252,7 @@ def sparse_mul(ind1, data1, ind2, data2):
 @numba.njit(
     [
         # "Tuple((i4[::1],f4[::1]))(i4[::1],f4[::1],i4[::1],f4[::1])",
-        numba.types.Tuple(
-            (
-                numba.types.ListType(numba.types.int32),
-                numba.types.ListType(numba.types.float32),
-            )
-        )(
+        numba.types.float32(
             numba.types.Array(numba.types.int32, 1, "C", readonly=True),
             numba.types.Array(numba.types.float32, 1, "C", readonly=True),
             numba.types.Array(numba.types.int32, 1, "C", readonly=True),

--- a/pynndescent/sparse.py
+++ b/pynndescent/sparse.py
@@ -55,7 +55,13 @@ def arr_intersect(ar1, ar2):
 
 # Some things require size of intersection; do this quickly; assume sorted arrays for speed
 @numba.njit(
-    'i4(i4[:],i4[:])',
+    [
+        "i4(i4[:],i4[:])",
+        numba.types.int32(
+            numba.types.Array(numba.types.int32, 1, readonly=True),
+            numba.types.Array(numba.types.int32, 1, readonly=True),
+        ),
+    ],
     locals={
         "i1": numba.uint16,
         "i2": numba.uint16,


### PR DESCRIPTION
Sparse binary distances were slow due to using naive intersection / union implementations. If we assume indices are sorted (which they should be as we require it elsewhere) then we can go much faster.