### PR TITLE
fix wminkowski implementation, and test for scipy >= 1.8.0

### DIFF
--- a/pynndescent/distances.py
+++ b/pynndescent/distances.py
@@ -142,7 +142,7 @@ def weighted_minkowski(x, y, w=_mock_ones, p=2):
     """
     result = 0.0
     for i in range(x.shape[0]):
-        result += (w[i] * np.abs(x[i] - y[i])) ** p
+        result += w[i] * np.abs(x[i] - y[i]) ** p
 
     return result ** (1.0 / p)
 

--- a/pynndescent/tests/test_distances.py
+++ b/pynndescent/tests/test_distances.py
@@ -242,12 +242,12 @@ def test_seuclidean(spatial_data):
     )
 
 
+@pytest.mark.skipif(
+    scipy_full_version < "1.8", reason="incorrect function in scipy<1.8"
+)
 def test_weighted_minkowski(spatial_data):
     v = np.abs(np.random.randn(spatial_data.shape[1]))
-    if scipy_full_version >= "1.8":
-        dist_matrix = pairwise_distances(spatial_data, metric="minkowski", w=v, p=3)
-    else:
-        dist_matrix = pairwise_distances(spatial_data, metric="wminkowski", w=v, p=3)
+    dist_matrix = pairwise_distances(spatial_data, metric="minkowski", w=v, p=3)
     test_matrix = np.array(
         [
             [

--- a/pynndescent/tests/test_distances.py
+++ b/pynndescent/tests/test_distances.py
@@ -5,6 +5,7 @@ import pynndescent.distances as dist
 import pynndescent.sparse as spdist
 from scipy import stats
 from scipy.sparse import csr_matrix
+from scipy.version import full_version as scipy_full_version
 from sklearn.metrics import pairwise_distances
 from sklearn.neighbors import BallTree
 from sklearn.preprocessing import normalize
@@ -241,6 +242,7 @@ def test_seuclidean(spatial_data):
     )
 
 
+@pytest.mark.skipif(scipy_full_version >= "1.8", reason="Function is deprecated")
 def test_weighted_minkowski(spatial_data):
     v = np.abs(np.random.randn(spatial_data.shape[1]))
     dist_matrix = pairwise_distances(spatial_data, metric="wminkowski", w=v, p=3)

--- a/pynndescent/tests/test_distances.py
+++ b/pynndescent/tests/test_distances.py
@@ -242,10 +242,12 @@ def test_seuclidean(spatial_data):
     )
 
 
-@pytest.mark.skipif(scipy_full_version >= "1.8", reason="Function is deprecated")
 def test_weighted_minkowski(spatial_data):
     v = np.abs(np.random.randn(spatial_data.shape[1]))
-    dist_matrix = pairwise_distances(spatial_data, metric="wminkowski", w=v, p=3)
+    if scipy_full_version >= "1.8":
+        dist_matrix = pairwise_distances(spatial_data, metric="minkowski", w=v, p=3)
+    else:
+        dist_matrix = pairwise_distances(spatial_data, metric="wminkowski", w=v, p=3)
     test_matrix = np.array(
         [
             [


### PR DESCRIPTION
Have seen a lot of failed tests, I think this should fix it...the `wminkowski` distance metric was removed in scipy 1.8.0.

edit: having verified that was the issue, I'm going to update this with a better option. scipy's version of`minkowski` now supports the `w` parameter. Rather than skipping the test it should just use that function if possible, so that the numba version is still tested.