### PR TITLE
[minor] clean up some strings

### DIFF
--- a/pynndescent/distances.py
+++ b/pynndescent/distances.py
@@ -744,11 +744,11 @@ def kantorovich(x, y, cost=_dummy_cost, max_iter=100000):
     #     print("WARNING: RESULT MIGHT BE INACCURATE\nMax number of iteration reached!")
     if solve_status == ProblemStatus.INFEASIBLE:
         raise ValueError(
-            "Optimal transport problem was INFEASIBLE. Please check " "inputs."
+            "Optimal transport problem was INFEASIBLE. Please check inputs."
         )
     elif solve_status == ProblemStatus.UNBOUNDED:
         raise ValueError(
-            "Optimal transport problem was UNBOUNDED. Please check " "inputs."
+            "Optimal transport problem was UNBOUNDED. Please check inputs."
         )
     result = total_cost(node_arc_data.flow, node_arc_data.cost)
 

--- a/pynndescent/tests/test_distances.py
+++ b/pynndescent/tests/test_distances.py
@@ -48,7 +48,7 @@ def test_spatial_check(spatial_data, metric):
     assert_array_almost_equal(
         test_matrix,
         dist_matrix,
-        err_msg="Distances don't match " "for metric {}".format(metric),
+        err_msg="Distances don't match for metric {}".format(metric),
     )
 
 
@@ -88,7 +88,7 @@ def test_binary_check(binary_data, metric):
     assert_array_almost_equal(
         test_matrix,
         dist_matrix,
-        err_msg="Distances don't match " "for metric {}".format(metric),
+        err_msg="Distances don't match for metric {}".format(metric),
     )
 
 
@@ -154,7 +154,7 @@ def test_sparse_spatial_check(sparse_spatial_data, metric, decimal=6):
     assert_array_almost_equal(
         test_matrix,
         dist_matrix,
-        err_msg="Sparse distances don't match " "for metric {}".format(metric),
+        err_msg="Sparse distances don't match for metric {}".format(metric),
         decimal=decimal,
     )
 
@@ -219,7 +219,7 @@ def test_sparse_binary_check(sparse_binary_data, metric):
     assert_array_almost_equal(
         test_matrix,
         dist_matrix,
-        err_msg="Sparse distances don't match " "for metric {}".format(metric),
+        err_msg="Sparse distances don't match for metric {}".format(metric),
     )
 
 
@@ -238,7 +238,7 @@ def test_seuclidean(spatial_data):
     assert_array_almost_equal(
         test_matrix,
         dist_matrix,
-        err_msg="Distances don't match " "for metric seuclidean",
+        err_msg="Distances don't match for metric seuclidean",
     )
 
 
@@ -260,7 +260,7 @@ def test_weighted_minkowski(spatial_data):
     assert_array_almost_equal(
         test_matrix,
         dist_matrix,
-        err_msg="Distances don't match " "for metric weighted_minkowski",
+        err_msg="Distances don't match for metric weighted_minkowski",
     )
 
 
@@ -279,7 +279,7 @@ def test_mahalanobis(spatial_data):
     assert_array_almost_equal(
         test_matrix,
         dist_matrix,
-        err_msg="Distances don't match " "for metric mahalanobis",
+        err_msg="Distances don't match for metric mahalanobis",
     )
 
 
@@ -299,7 +299,7 @@ def test_haversine(spatial_data):
     assert_array_almost_equal(
         test_matrix,
         dist_matrix,
-        err_msg="Distances don't match " "for metric haversine",
+        err_msg="Distances don't match for metric haversine",
     )
 
 

--- a/pynndescent/tests/test_pynndescent_.py
+++ b/pynndescent/tests/test_pynndescent_.py
@@ -29,7 +29,7 @@ def test_nn_descent_neighbor_accuracy(nn_data, seed):
 
     percent_correct = num_correct / (nn_data.shape[0] * 10)
     assert percent_correct >= 0.98, (
-        "NN-descent did not get 99% " "accuracy on nearest neighbors"
+        "NN-descent did not get 99% accuracy on nearest neighbors"
     )
 
 
@@ -48,7 +48,7 @@ def test_angular_nn_descent_neighbor_accuracy(nn_data, seed):
 
     percent_correct = num_correct / (nn_data.shape[0] * 10)
     assert percent_correct >= 0.98, (
-        "NN-descent did not get 99% " "accuracy on nearest neighbors"
+        "NN-descent did not get 99% accuracy on nearest neighbors"
     )
 
 
@@ -70,7 +70,7 @@ def test_sparse_nn_descent_neighbor_accuracy(sparse_nn_data, seed):
 
     percent_correct = num_correct / (sparse_nn_data.shape[0] * 10)
     assert percent_correct >= 0.85, (
-        "Sparse NN-descent did not get 95% " "accuracy on nearest neighbors"
+        "Sparse NN-descent did not get 95% accuracy on nearest neighbors"
     )
 
 
@@ -93,7 +93,7 @@ def test_sparse_angular_nn_descent_neighbor_accuracy(sparse_nn_data):
 
     percent_correct = num_correct / (sparse_nn_data.shape[0] * 10)
     assert percent_correct >= 0.85, (
-        "Sparse angular NN-descent did not get 98% " "accuracy on nearest neighbors"
+        "Sparse angular NN-descent did not get 98% accuracy on nearest neighbors"
     )
 
 
@@ -110,7 +110,7 @@ def test_nn_descent_query_accuracy(nn_data):
 
     percent_correct = num_correct / (true_indices.shape[0] * 10)
     assert percent_correct >= 0.95, (
-        "NN-descent query did not get 95% " "accuracy on nearest neighbors"
+        "NN-descent query did not get 95% accuracy on nearest neighbors"
     )
 
 
@@ -127,7 +127,7 @@ def test_nn_descent_query_accuracy_angular(nn_data):
 
     percent_correct = num_correct / (true_indices.shape[0] * 10)
     assert percent_correct >= 0.95, (
-        "NN-descent query did not get 95% " "accuracy on nearest neighbors"
+        "NN-descent query did not get 95% accuracy on nearest neighbors"
     )
 
 
@@ -146,7 +146,7 @@ def test_sparse_nn_descent_query_accuracy(sparse_nn_data):
 
     percent_correct = num_correct / (true_indices.shape[0] * 10)
     assert percent_correct >= 0.95, (
-        "Sparse NN-descent query did not get 95% " "accuracy on nearest neighbors"
+        "Sparse NN-descent query did not get 95% accuracy on nearest neighbors"
     )
 
 
@@ -165,7 +165,7 @@ def test_sparse_nn_descent_query_accuracy_angular(sparse_nn_data):
 
     percent_correct = num_correct / (true_indices.shape[0] * 10)
     assert percent_correct >= 0.95, (
-        "Sparse NN-descent query did not get 95% " "accuracy on nearest neighbors"
+        "Sparse NN-descent query did not get 95% accuracy on nearest neighbors"
     )
 
 
@@ -210,7 +210,7 @@ def test_random_state_none(nn_data, spatial_data):
 
     percent_correct = num_correct / (spatial_data.shape[0] * 10)
     assert percent_correct >= 0.99, (
-        "NN-descent did not get 99% " "accuracy on nearest neighbors"
+        "NN-descent did not get 99% accuracy on nearest neighbors"
     )
 
 
@@ -283,7 +283,7 @@ def test_deduplicated_data_behaves_normally(seed, cosine_hang_data):
 
     proportion_correct = num_correct / (data.shape[0] * n_neighbors)
     assert proportion_correct >= 0.95, (
-        "NN-descent did not get 95%" " accuracy on nearest neighbors"
+        "NN-descent did not get 95% accuracy on nearest neighbors"
     )
 
 


### PR DESCRIPTION
I'm guessing that a previous run of `black` put these split strings onto the same line. It was bugging me.