### PR TITLE
was overwriting input indices in graph utils function

### DIFF
--- a/pynndescent/graph_utils.py
+++ b/pynndescent/graph_utils.py
@@ -145,7 +145,7 @@ def find_component_connection_edge(
     best_edge = (indices[0][0], indices[1][0])
 
     while changed[0] or changed[1]:
-        indices, dists, _ = search_closure(
+        inds, dists, _ = search_closure(
             query_points, candidate_indices, search_size, epsilon, visited
         )
         inds, dists = deheap_sort(inds, dists)


### PR DESCRIPTION
I introduced a bug in #168 in the code for `graph_utils.find_component_connection_edge`, which I suppose is not currently tested. Mixed up `indices` and `inds` as I was refactoring various locations.