### PR TITLE
fix: remove cache=True from numba functions that implement parallel=True

### DIFF
--- a/pynndescent/optimal_transport.py
+++ b/pynndescent/optimal_transport.py
@@ -935,7 +935,7 @@ def network_simplex_core(node_arc_data, spanning_tree, graph, max_iter):
     fastmath=True,
     parallel=True,
     locals={"diff": numba.float32, "result": numba.float32},
-    cache=True,
+    cache=False,
 )
 def right_marginal_error(u, K, v, y):
     uK = u @ K
@@ -950,7 +950,7 @@ def right_marginal_error(u, K, v, y):
     fastmath=True,
     parallel=True,
     locals={"diff": numba.float32, "result": numba.float32},
-    cache=True,
+    cache=False,
 )
 def right_marginal_error_batch(u, K, v, y):
     uK = K.T @ u
@@ -962,7 +962,7 @@ def right_marginal_error_batch(u, K, v, y):
     return np.sqrt(result)
 
 
-@numba.njit(fastmath=True, parallel=True, cache=True)
+@numba.njit(fastmath=True, parallel=True, cache=False)
 def transport_plan(K, u, v):
     i_dim = K.shape[0]
     j_dim = K.shape[1]
@@ -974,7 +974,7 @@ def transport_plan(K, u, v):
     return result
 
 
-@numba.njit(fastmath=True, parallel=True, locals={"result": numba.float32}, cache=True)
+@numba.njit(fastmath=True, parallel=True, locals={"result": numba.float32}, cache=False)
 def relative_change_in_plan(old_u, old_v, new_u, new_v):
     i_dim = old_u.shape[0]
     j_dim = old_v.shape[0]
@@ -987,7 +987,7 @@ def relative_change_in_plan(old_u, old_v, new_u, new_v):
     return result / (i_dim * j_dim)
 
 
-@numba.njit(fastmath=True, parallel=True, cache=True)
+@numba.njit(fastmath=True, parallel=True, cache=False)
 def precompute_K_prime(K, x):
     i_dim = K.shape[0]
     j_dim = K.shape[1]
@@ -1003,7 +1003,7 @@ def precompute_K_prime(K, x):
     return result
 
 
-@numba.njit(fastmath=True, parallel=True, cache=True)
+@numba.njit(fastmath=True, parallel=True, cache=False)
 def K_from_cost(cost, regularization):
     i_dim = cost.shape[0]
     j_dim = cost.shape[1]
@@ -1131,7 +1131,7 @@ def sinkhorn_distance(x, y, cost=_dummy_cost, regularization=1.0):
     return result
 
 
-@numba.njit(fastmath=True, parallel=True, cache=True)
+@numba.njit(fastmath=True, parallel=True, cache=False)
 def sinkhorn_distance_batch(x, y, cost=_dummy_cost, regularization=1.0):
     dim_x = x.shape[0]
     dim_y = y.shape[0]

--- a/pynndescent/pynndescent_.py
+++ b/pynndescent/pynndescent_.py
@@ -63,7 +63,7 @@ def is_c_contiguous(array_like):
     return flags is not None and flags["C_CONTIGUOUS"]
 
 
-@numba.njit(parallel=True, cache=True)
+@numba.njit(parallel=True, cache=False)
 def generate_leaf_updates(leaf_block, dist_thresholds, data, dist):
 
     updates = [[(-1, -1, np.inf)] for i in range(leaf_block.shape[0])]
@@ -156,7 +156,7 @@ def init_from_neighbor_graph(heap, indices, distances):
     return
 
 
-@numba.njit(parallel=True, cache=True)
+@numba.njit(parallel=True, cache=False)
 def generate_graph_updates(
     new_candidate_block, old_candidate_block, dist_thresholds, data, dist
 ):

--- a/pynndescent/rp_trees.py
+++ b/pynndescent/rp_trees.py
@@ -1219,7 +1219,7 @@ def renumbaify_tree(tree):
         "result": numba.float32,
         "i": numba.uint32,
     },
-    cache=True,
+    cache=False,
 )
 def score_tree(tree, neighbor_indices, data, rng_state):
     result = 0.0
@@ -1237,7 +1237,7 @@ def score_tree(tree, neighbor_indices, data, rng_state):
     return result / numba.float32(neighbor_indices.shape[0])
 
 
-@numba.njit(nogil=True, parallel=True, locals={"node": numba.int32}, cache=True)
+@numba.njit(nogil=True, parallel=True, locals={"node": numba.int32}, cache=False)
 def score_linked_tree(tree, neighbor_indices):
     result = 0.0
     n_nodes = len(tree.children)

--- a/pynndescent/sparse.py
+++ b/pynndescent/sparse.py
@@ -938,7 +938,7 @@ def sparse_symmetric_kl_divergence(ind1, data1, ind2, data2):
     return symmetric_kl_divergence(dense_data1, dense_data2)
 
 
-@numba.njit(parallel=True, cache=True)
+@numba.njit(parallel=True, cache=False)
 def diversify(
     indices,
     distances,
@@ -993,7 +993,7 @@ def diversify(
     return indices, distances
 
 
-@numba.njit(parallel=True, cache=True)
+@numba.njit(parallel=True, cache=False)
 def diversify_csr(
     graph_indptr,
     graph_indices,

--- a/pynndescent/sparse_nndescent.py
+++ b/pynndescent/sparse_nndescent.py
@@ -24,7 +24,7 @@ locale.setlocale(locale.LC_NUMERIC, "C")
 EMPTY_GRAPH = make_heap(1, 1)
 
 
-@numba.njit(parallel=True, cache=True)
+@numba.njit(parallel=True, cache=False)
 def generate_leaf_updates(leaf_block, dist_thresholds, inds, indptr, data, dist):
 
     updates = [[(-1, -1, np.inf)] for i in range(leaf_block.shape[0])]
@@ -122,7 +122,7 @@ def init_random(n_neighbors, inds, indptr, data, heap, dist, rng_state):
     return
 
 
-@numba.njit(parallel=True, cache=True)
+@numba.njit(parallel=True, cache=False)
 def generate_graph_updates(
     new_candidate_block, old_candidate_block, dist_thresholds, inds, indptr, data, dist
 ):

--- a/pynndescent/utils.py
+++ b/pynndescent/utils.py
@@ -223,7 +223,7 @@ def siftdown(heap1, heap2, elt):
             elt = swap
 
 
-@numba.njit(parallel=True, cache=True)
+@numba.njit(parallel=True, cache=False)
 def deheap_sort(indices, distances):
     """Given two arrays representing a heap (indices and distances), reorder the 
      arrays by increasing distance. This is effectively just the second half of
@@ -294,7 +294,7 @@ def deheap_sort(indices, distances):
 #         return -1
 
 
-@numba.njit(parallel=True, locals={"idx": numba.types.int64}, cache=True)
+@numba.njit(parallel=True, locals={"idx": numba.types.int64}, cache=False)
 def new_build_candidates(current_graph, max_candidates, rng_state, n_threads):
     """Build a heap of candidate neighbors for nearest neighbor descent. For
     each vertex the candidate neighbors are any current neighbors, and any
@@ -594,7 +594,7 @@ def checked_flagged_heap_push(priorities, indices, flags, p, n, f):
         "i": numba.uint32,
         "j": numba.uint32,
     },
-    cache=True,
+    cache=False,
 )
 def apply_graph_updates_low_memory(current_graph, updates, n_threads):
 
@@ -689,7 +689,7 @@ def initalize_heap_from_graph_indices(heap, graph_indices, data, metric):
     return heap
 
 
-@numba.njit(parallel=True, cache=True)
+@numba.njit(parallel=True, cache=False)
 def sparse_initalize_heap_from_graph_indices(
     heap, graph_indices, data_indptr, data_indices, data_vals, metric
 ):


### PR DESCRIPTION
This is a pull request addressing several issues indicating that `pynndescent` segfaults randomly:
- https://github.com/lmcinnes/umap/issues/747
- https://github.com/lmcinnes/umap/issues/421
- https://github.com/lmcinnes/pynndescent/issues/142
- And maybe https://github.com/lmcinnes/pynndescent/issues/128

The segfaults are a result of this known numba issue: 
- https://github.com/numba/numba/pull/7522
Using `cache=True` and `parallel=True` only caches a numba function for the original number of designated threads. If the thread count being used is changed then numba segfaults.

The fix involves not caching any numba functions that utilize `parallel=True`. Most functions are still cached so import times should not be noticeably different.