### PR TITLE
Fixing the bug with n_trees introduced when fixing #180

### DIFF
--- a/pynndescent/distances.py
+++ b/pynndescent/distances.py
@@ -359,7 +359,7 @@ def haversine(x, y):
         raise ValueError("haversine is only defined for 2 dimensional graph_data")
     sin_lat = np.sin(0.5 * (x[0] - y[0]))
     sin_long = np.sin(0.5 * (x[1] - y[1]))
-    result = np.sqrt(sin_lat ** 2 + np.cos(x[0]) * np.cos(y[0]) * sin_long ** 2)
+    result = np.sqrt(sin_lat**2 + np.cos(x[0]) * np.cos(y[0]) * sin_long**2)
     return 2.0 * np.arcsin(result)
 
 
@@ -565,8 +565,8 @@ def correlation(x, y):
     for i in range(x.shape[0]):
         shifted_x = x[i] - mu_x
         shifted_y = y[i] - mu_y
-        norm_x += shifted_x ** 2
-        norm_y += shifted_y ** 2
+        norm_x += shifted_x**2
+        norm_y += shifted_y**2
         dot_product += shifted_x * shifted_y
 
     if norm_x == 0.0 and norm_y == 0.0:

--- a/pynndescent/pynndescent_.py
+++ b/pynndescent/pynndescent_.py
@@ -9,7 +9,13 @@ import numpy as np
 from sklearn.utils import check_random_state, check_array
 from sklearn.preprocessing import normalize
 from sklearn.base import BaseEstimator, TransformerMixin
-from scipy.sparse import csr_matrix, coo_matrix, isspmatrix_csr, vstack as sparse_vstack, issparse
+from scipy.sparse import (
+    csr_matrix,
+    coo_matrix,
+    isspmatrix_csr,
+    vstack as sparse_vstack,
+    issparse,
+)
 
 import heapq
 
@@ -694,7 +700,9 @@ class NNDescent:
         self.parallel_batch_queries = parallel_batch_queries
         self.verbose = verbose
 
-        if getattr(data, "dtype", None) == np.float32 and (issparse(data) or is_c_contiguous(data)):
+        if getattr(data, "dtype", None) == np.float32 and (
+            issparse(data) or is_c_contiguous(data)
+        ):
             copy_on_normalize = True
         else:
             copy_on_normalize = False
@@ -1133,7 +1141,9 @@ class NNDescent:
             if self._is_sparse:
                 self._raw_data = self._raw_data[self._vertex_order, :]
             else:
-                self._raw_data = np.ascontiguousarray(self._raw_data[self._vertex_order, :])
+                self._raw_data = np.ascontiguousarray(
+                    self._raw_data[self._vertex_order, :]
+                )
 
             tree_order = np.argsort(self._vertex_order)
             self._search_forest = tuple(
@@ -1187,6 +1197,7 @@ class NNDescent:
 
             self._tree_search = tree_search_closure
         else:
+
             @numba.njit()
             def tree_search_closure(point, rng_state):
                 return (0, 0)
@@ -1368,6 +1379,7 @@ class NNDescent:
 
             self._tree_search = sparse_tree_search_closure
         else:
+
             @numba.njit()
             def sparse_tree_search_closure(point_inds, point_data, rng_state):
                 return (0, 0)
@@ -1427,7 +1439,7 @@ class NNDescent:
                 current_query_data = query_data[query_indptr[i] : query_indptr[i + 1]]
 
                 if dist == alternative_dot or dist == alternative_cosine:
-                    norm = np.sqrt((current_query_data ** 2).sum())
+                    norm = np.sqrt((current_query_data**2).sum())
                     if norm > 0.0:
                         current_query_data = current_query_data / norm
                     else:
@@ -1457,9 +1469,11 @@ class NNDescent:
                         data_indptr[candidate] : data_indptr[candidate + 1]
                     ]
 
-                    d = np.float32(dist(
-                        from_inds, from_data, current_query_inds, current_query_data
-                    ))
+                    d = np.float32(
+                        dist(
+                            from_inds, from_data, current_query_inds, current_query_data
+                        )
+                    )
                     # indices are guaranteed different
                     simple_heap_push(heap_priorities, heap_indices, d, candidate)
                     heapq.heappush(seed_set, (d, candidate))
@@ -1478,12 +1492,14 @@ class NNDescent:
                                 data_indptr[candidate] : data_indptr[candidate + 1]
                             ]
 
-                            d = np.float32(dist(
-                                from_inds,
-                                from_data,
-                                current_query_inds,
-                                current_query_data,
-                            ))
+                            d = np.float32(
+                                dist(
+                                    from_inds,
+                                    from_data,
+                                    current_query_inds,
+                                    current_query_data,
+                                )
+                            )
 
                             simple_heap_push(
                                 heap_priorities, heap_indices, d, candidate
@@ -1513,12 +1529,14 @@ class NNDescent:
                                 data_indptr[candidate] : data_indptr[candidate + 1]
                             ]
 
-                            d = np.float32(dist(
-                                from_inds,
-                                from_data,
-                                current_query_inds,
-                                current_query_data,
-                            ))
+                            d = np.float32(
+                                dist(
+                                    from_inds,
+                                    from_data,
+                                    current_query_inds,
+                                    current_query_data,
+                                )
+                            )
 
                             if d < distance_bound:
                                 simple_heap_push(
@@ -1729,9 +1747,9 @@ class NNDescent:
             # Remove search graph and search function
             # and rerun prepare if it was run previously
             if (
-                    hasattr(self, "_search_graph") or
-                    hasattr(self, "_search_function") or
-                    hasattr(self, "_search_forest")
+                hasattr(self, "_search_graph")
+                or hasattr(self, "_search_function")
+                or hasattr(self, "_search_forest")
             ):
                 if hasattr(self, "_search_graph"):
                     del self._search_graph

--- a/pynndescent/pynndescent_.py
+++ b/pynndescent/pynndescent_.py
@@ -676,7 +676,7 @@ class NNDescent:
             n_iters = max(5, int(round(np.log2(data.shape[0]))))
 
         self.n_trees = n_trees
-        self.n_trees_for_update = max(1, int(np.round(self.n_trees / 3)))
+        self.n_trees_after_update = max(1, int(np.round(self.n_trees / 3)))
         self.n_neighbors = n_neighbors
         self.metric = metric
         self.metric_kwds = metric_kwds
@@ -1688,10 +1688,11 @@ class NNDescent:
         if self._is_sparse:
             raise NotImplementedError("Sparse update not complete yet")
         else:
+            self.n_trees = self.n_trees_after_update
             self._rp_forest = make_forest(
                 self._raw_data,
                 self.n_neighbors,
-                self.n_trees_for_update,
+                self.n_trees,
                 self.leaf_size,
                 rng_state,
                 current_random_state,

--- a/pynndescent/pynndescent_.py
+++ b/pynndescent/pynndescent_.py
@@ -676,6 +676,7 @@ class NNDescent:
             n_iters = max(5, int(round(np.log2(data.shape[0]))))
 
         self.n_trees = n_trees
+        self.n_trees_for_update = max(1, int(np.round(self.n_trees / 3)))
         self.n_neighbors = n_neighbors
         self.metric = metric
         self.metric_kwds = metric_kwds
@@ -1687,11 +1688,10 @@ class NNDescent:
         if self._is_sparse:
             raise NotImplementedError("Sparse update not complete yet")
         else:
-            self.n_trees = int(np.round(self.n_trees / 3))
             self._rp_forest = make_forest(
                 self._raw_data,
                 self.n_neighbors,
-                self.n_trees,
+                self.n_trees_for_update,
                 self.leaf_size,
                 rng_state,
                 current_random_state,

--- a/pynndescent/rp_trees.py
+++ b/pynndescent/rp_trees.py
@@ -8,7 +8,13 @@ import numpy as np
 import numba
 import scipy.sparse
 
-from pynndescent.sparse import sparse_mul, sparse_diff, sparse_sum, arr_intersect, sparse_dot_product
+from pynndescent.sparse import (
+    sparse_mul,
+    sparse_diff,
+    sparse_sum,
+    arr_intersect,
+    sparse_dot_product,
+)
 from pynndescent.utils import tau_rand_int, norm
 import joblib
 
@@ -908,7 +914,9 @@ def sparse_select_side(hyperplane, offset, point_inds, point_data, rng_state):
     hyperplane_inds = hyperplane[0, :hyperplane_size].astype(np.int32)
     hyperplane_data = hyperplane[1, :hyperplane_size]
 
-    margin += sparse_dot_product(hyperplane_inds, hyperplane_data, point_inds, point_data)
+    margin += sparse_dot_product(
+        hyperplane_inds, hyperplane_data, point_inds, point_data
+    )
 
     if abs(margin) < EPS:
         side = tau_rand_int(rng_state) % 2

--- a/pynndescent/sparse.py
+++ b/pynndescent/sparse.py
@@ -53,6 +53,7 @@ def arr_intersect(ar1, ar2):
     aux.sort()
     return aux[:-1][aux[1:] == aux[:-1]]
 
+
 # Some things require size of intersection; do this quickly; assume sorted arrays for speed
 @numba.njit(
     [
@@ -65,7 +66,7 @@ def arr_intersect(ar1, ar2):
     locals={
         "i1": numba.uint16,
         "i2": numba.uint16,
-    }
+    },
 )
 def fast_intersection_size(ar1, ar2):
     if ar1.shape[0] == 0 or ar2.shape[0] == 0:
@@ -201,6 +202,7 @@ def sparse_sum(ind1, data1, ind2, data2):
 def sparse_diff(ind1, data1, ind2, data2):
     return sparse_sum(ind1, data1, ind2, -data2)
 
+
 @numba.njit(
     [
         # "Tuple((i4[::1],f4[::1]))(i4[::1],f4[::1],i4[::1],f4[::1])",
@@ -251,6 +253,7 @@ def sparse_mul(ind1, data1, ind2, data2):
             i2 += 1
 
     return result_ind, result_data
+
 
 @numba.njit(
     [
@@ -308,7 +311,8 @@ def sparse_dot_product(ind1, data1, ind2, data2):
                 return result
             j2 = ind2[i2]
 
-    return result # unreachable
+    return result  # unreachable
+
 
 # Return dense vectors supported on the union of the non-zero valued indices
 @numba.njit()
@@ -717,10 +721,10 @@ def sparse_correlation(ind1, data1, ind2, data2, n_features):
         shifted_data2[i] = data2[i] - mu_y
 
     norm1 = np.sqrt(
-        (norm(shifted_data1) ** 2) + (n_features - ind1.shape[0]) * (mu_x ** 2)
+        (norm(shifted_data1) ** 2) + (n_features - ind1.shape[0]) * (mu_x**2)
     )
     norm2 = np.sqrt(
-        (norm(shifted_data2) ** 2) + (n_features - ind2.shape[0]) * (mu_y ** 2)
+        (norm(shifted_data2) ** 2) + (n_features - ind2.shape[0]) * (mu_y**2)
     )
 
     dot_prod_inds, dot_prod_data = sparse_mul(ind1, shifted_data1, ind2, shifted_data2)

--- a/pynndescent/tests/test_pynndescent_.py
+++ b/pynndescent/tests/test_pynndescent_.py
@@ -436,6 +436,7 @@ def test_joblib_dump():
     np.testing.assert_equal(neighbors1, neighbors2)
     np.testing.assert_equal(distances1, distances2)
 
+
 @pytest.mark.parametrize("metric", ["euclidean", "cosine"])
 def test_update_no_prepare_query_accuracy(nn_data, metric):
     nnd = NNDescent(nn_data[200:800], metric=metric, n_neighbors=10, random_state=None)
@@ -455,9 +456,16 @@ def test_update_no_prepare_query_accuracy(nn_data, metric):
         "NN-descent query did not get 95% " "accuracy on nearest neighbors"
     )
 
+
 @pytest.mark.parametrize("metric", ["euclidean", "cosine"])
 def test_update_w_prepare_query_accuracy(nn_data, metric):
-    nnd = NNDescent(nn_data[200:800], metric=metric, n_neighbors=10, random_state=None, compressed=False)
+    nnd = NNDescent(
+        nn_data[200:800],
+        metric=metric,
+        n_neighbors=10,
+        random_state=None,
+        compressed=False,
+    )
     nnd.prepare()
 
     nnd.update(nn_data[800:])
@@ -480,7 +488,13 @@ def test_update_w_prepare_query_accuracy(nn_data, metric):
 
 @pytest.mark.parametrize("metric", ["euclidean", "cosine"])
 def test_update_w_prepare_query_accuracy(nn_data, metric):
-    nnd = NNDescent(nn_data[200:800], metric=metric, n_neighbors=10, random_state=None, compressed=False)
+    nnd = NNDescent(
+        nn_data[200:800],
+        metric=metric,
+        n_neighbors=10,
+        random_state=None,
+        compressed=False,
+    )
     nnd.prepare()
 
     nnd.update(nn_data[800:])
@@ -499,27 +513,26 @@ def test_update_w_prepare_query_accuracy(nn_data, metric):
     assert percent_correct >= 0.95, (
         "NN-descent query did not get 95% " "accuracy on nearest neighbors"
     )
+
 
 @pytest.mark.parametrize("n_trees", [1, 2, 3, 10])
-def test_tree_numbers_after_multiple_updates(nn_data, n_trees):
+def test_tree_numbers_after_multiple_updates(n_trees):
     trees_after_update = max(1, int(np.round(n_trees / 3)))
 
     nnd = NNDescent(np.array([[1.0]]), n_neighbors=1, n_trees=n_trees)
 
-    assert nnd.n_trees == n_trees, (
-        "NN-descent update changed the number of trees"
-    )
-    assert nnd.n_trees_after_update == trees_after_update, (
-        "The value of the n_trees_after_update in NN-descent after update(s) is wrong"
-    )
+    assert nnd.n_trees == n_trees, "NN-descent update changed the number of trees"
+    assert (
+        nnd.n_trees_after_update == trees_after_update
+    ), "The value of the n_trees_after_update in NN-descent after update(s) is wrong"
     for i in range(5):
         nnd.update(np.array([[i]], dtype=np.float64))
-        assert nnd.n_trees == trees_after_update, (
-            "The value of the n_trees in NN-descent after update(s) is wrong"
-        )
-        assert nnd.n_trees_after_update == trees_after_update, (
-            "The value of the n_trees_after_update in NN-descent after update(s) is wrong"
-        )
+        assert (
+            nnd.n_trees == trees_after_update
+        ), "The value of the n_trees in NN-descent after update(s) is wrong"
+        assert (
+            nnd.n_trees_after_update == trees_after_update
+        ), "The value of the n_trees_after_update in NN-descent after update(s) is wrong"
 
 
 @pytest.mark.parametrize("metric", ["euclidean", "cosine"])

--- a/pynndescent/tests/test_pynndescent_.py
+++ b/pynndescent/tests/test_pynndescent_.py
@@ -477,6 +477,51 @@ def test_update_w_prepare_query_accuracy(nn_data, metric):
         "NN-descent query did not get 95% " "accuracy on nearest neighbors"
     )
 
+
+@pytest.mark.parametrize("metric", ["euclidean", "cosine"])
+def test_update_w_prepare_query_accuracy(nn_data, metric):
+    nnd = NNDescent(nn_data[200:800], metric=metric, n_neighbors=10, random_state=None, compressed=False)
+    nnd.prepare()
+
+    nnd.update(nn_data[800:])
+    nnd.prepare()
+
+    knn_indices, _ = nnd.query(nn_data[:200], k=10, epsilon=0.2)
+
+    true_nnd = NearestNeighbors(metric=metric).fit(nn_data[200:])
+    true_indices = true_nnd.kneighbors(nn_data[:200], 10, return_distance=False)
+
+    num_correct = 0.0
+    for i in range(true_indices.shape[0]):
+        num_correct += np.sum(np.in1d(true_indices[i], knn_indices[i]))
+
+    percent_correct = num_correct / (true_indices.shape[0] * 10)
+    assert percent_correct >= 0.95, (
+        "NN-descent query did not get 95% " "accuracy on nearest neighbors"
+    )
+
+@pytest.mark.parametrize("n_trees", [1, 2, 3, 10])
+def test_tree_numbers_after_multiple_updates(nn_data, n_trees):
+    trees_after_update = max(1, int(np.round(n_trees / 3)))
+
+    nnd = NNDescent(np.array([[1.0]]), n_neighbors=1, n_trees=n_trees)
+
+    assert nnd.n_trees == n_trees, (
+        "NN-descent update changed the number of trees"
+    )
+    assert nnd.n_trees_after_update == trees_after_update, (
+        "The value of the n_trees_after_update in NN-descent after update(s) is wrong"
+    )
+    for i in range(5):
+        nnd.update(np.array([[i]], dtype=np.float64))
+        assert nnd.n_trees == trees_after_update, (
+            "The value of the n_trees in NN-descent after update(s) is wrong"
+        )
+        assert nnd.n_trees_after_update == trees_after_update, (
+            "The value of the n_trees_after_update in NN-descent after update(s) is wrong"
+        )
+
+
 @pytest.mark.parametrize("metric", ["euclidean", "cosine"])
 def test_tree_init_false(nn_data, metric):
     nnd = NNDescent(

--- a/pynndescent/tests/test_rank.py
+++ b/pynndescent/tests/test_rank.py
@@ -74,15 +74,15 @@ def test_rankdata_object_string():
 
 
 def test_large_int():
-    data = np.array([2 ** 60, 2 ** 60 + 1], dtype=np.uint64)
+    data = np.array([2**60, 2**60 + 1], dtype=np.uint64)
     r = rankdata(data)
     assert_array_equal(r, [1.0, 2.0])
 
-    data = np.array([2 ** 60, 2 ** 60 + 1], dtype=np.int64)
+    data = np.array([2**60, 2**60 + 1], dtype=np.int64)
     r = rankdata(data)
     assert_array_equal(r, [1.0, 2.0])
 
-    data = np.array([2 ** 60, -(2 ** 60) + 1], dtype=np.int64)
+    data = np.array([2**60, -(2**60) + 1], dtype=np.int64)
     r = rankdata(data)
     assert_array_equal(r, [2.0, 1.0])
 

--- a/pynndescent/utils.py
+++ b/pynndescent/utils.py
@@ -225,7 +225,7 @@ def siftdown(heap1, heap2, elt):
 
 @numba.njit(parallel=True, cache=False)
 def deheap_sort(indices, distances):
-    """Given two arrays representing a heap (indices and distances), reorder the 
+    """Given two arrays representing a heap (indices and distances), reorder the
      arrays by increasing distance. This is effectively just the second half of
      heap sort (the first half not being required since we already have the
      graph_data in a heap).


### PR DESCRIPTION
With every call of  `nn_descent.update(xs)`, `nn_descent.n_trees` was divided by `3` which caused empty search forests (since the number of trees dropped to 0).

This is now fixed and the correspodning test is included in the tests (`test_tree_numbers_after_multiple_updates(n_trees)`).

After that, the code was formatted with `black` which changed some other files that I haven't touched otherwise.