### PR TITLE
Accepting rp trees with no splits

### DIFF
--- a/pynndescent/pynndescent_.py
+++ b/pynndescent/pynndescent_.py
@@ -969,7 +969,7 @@ class NNDescent:
                         self._angular_trees,
                     )
                     self._search_forest = [
-                        convert_tree_format(tree, self._raw_data.shape[0])
+                        convert_tree_format(tree, self._raw_data.shape[0], self._raw_data.shape[1])
                         for tree in rp_forest
                     ]
                 else:
@@ -988,7 +988,7 @@ class NNDescent:
                 best_trees = [self._rp_forest[idx] for idx in best_tree_indices]
                 del self._rp_forest
                 self._search_forest = [
-                    convert_tree_format(tree, self._raw_data.shape[0])
+                    convert_tree_format(tree, self._raw_data.shape[0], self._raw_data.shape[1])
                     for tree in best_trees
                 ]
 
@@ -1685,11 +1685,36 @@ class NNDescent:
         return indices, dists
 
     def update(self, X):
+        """
+        Updates the graph with the fresh data X. if add.
+        In this case, X should represent the actual data.
+
+        If not add, X is a list of indices that should be removed.
+
+
+        Parameters
+        ----------
+        X
+        update_indices
+
+        Returns
+        -------
+
+        """
         current_random_state = check_random_state(self.random_state)
         rng_state = current_random_state.randint(INT32_MIN, INT32_MAX, 3).astype(
             np.int64
         )
-        X = check_array(X, dtype=np.float32, accept_sparse="csr", order="C")
+        # if add:
+        #     X = check_array(X, dtype=np.float32, accept_sparse="csr", order="C")
+        # else:
+        #     try:
+        #         X = list(map(int, X))
+        #     except (ValueError, TypeError):
+        #         raise ValueError(
+        #             "When updating existing instances via update(X, add=False), "
+        #             "X should be convertable to list of ints."
+        #         )
 
         if hasattr(self, "_vertex_order"):
             original_order = np.argsort(self._vertex_order)

--- a/pynndescent/pynndescent_.py
+++ b/pynndescent/pynndescent_.py
@@ -969,7 +969,9 @@ class NNDescent:
                         self._angular_trees,
                     )
                     self._search_forest = [
-                        convert_tree_format(tree, self._raw_data.shape[0], self._raw_data.shape[1])
+                        convert_tree_format(
+                            tree, self._raw_data.shape[0], self._raw_data.shape[1]
+                        )
                         for tree in rp_forest
                     ]
                 else:
@@ -988,7 +990,9 @@ class NNDescent:
                 best_trees = [self._rp_forest[idx] for idx in best_tree_indices]
                 del self._rp_forest
                 self._search_forest = [
-                    convert_tree_format(tree, self._raw_data.shape[0], self._raw_data.shape[1])
+                    convert_tree_format(
+                        tree, self._raw_data.shape[0], self._raw_data.shape[1]
+                    )
                     for tree in best_trees
                 ]
 

--- a/pynndescent/pynndescent_.py
+++ b/pynndescent/pynndescent_.py
@@ -1685,36 +1685,12 @@ class NNDescent:
         return indices, dists
 
     def update(self, X):
-        """
-        Updates the graph with the fresh data X. if add.
-        In this case, X should represent the actual data.
 
-        If not add, X is a list of indices that should be removed.
-
-
-        Parameters
-        ----------
-        X
-        update_indices
-
-        Returns
-        -------
-
-        """
         current_random_state = check_random_state(self.random_state)
         rng_state = current_random_state.randint(INT32_MIN, INT32_MAX, 3).astype(
             np.int64
         )
-        # if add:
-        #     X = check_array(X, dtype=np.float32, accept_sparse="csr", order="C")
-        # else:
-        #     try:
-        #         X = list(map(int, X))
-        #     except (ValueError, TypeError):
-        #         raise ValueError(
-        #             "When updating existing instances via update(X, add=False), "
-        #             "X should be convertable to list of ints."
-        #         )
+        X = check_array(X, dtype=np.float32, accept_sparse="csr", order="C")
 
         if hasattr(self, "_vertex_order"):
             original_order = np.argsort(self._vertex_order)

--- a/pynndescent/rp_trees.py
+++ b/pynndescent/rp_trees.py
@@ -1139,35 +1139,17 @@ def num_nodes_and_leaves(tree):
     return n_nodes, n_leaves
 
 
-@numba.njit(cache=True)
-def dense_hyperplane_dim(hyperplanes):
-    for i in range(len(hyperplanes)):
-        if hyperplanes[i].shape[0] > 1:
-            return hyperplanes[i].shape[0]
-
-    raise ValueError("No hyperplanes of adequate size were found!")
-
-
-@numba.njit(cache=True)
-def sparse_hyperplane_dim(hyperplanes):
-    max_dim = 0
-    for i in range(len(hyperplanes)):
-        if hyperplanes[i].shape[1] > max_dim:
-            max_dim = hyperplanes[i].shape[1]
-    return max_dim
-
-
 def convert_tree_format(tree, data_size, data_dim):
     n_nodes, n_leaves = num_nodes_and_leaves(tree)
     is_sparse = False
     if tree.hyperplanes[0].ndim == 1:
         # dense hyperplanes
-        hyperplane_dim = data_dim  # dense_hyperplane_dim(tree.hyperplanes)
+        hyperplane_dim = data_dim
         hyperplanes = np.zeros((n_nodes, hyperplane_dim), dtype=np.float32)
     else:
         # sparse hyperplanes
         is_sparse = True
-        hyperplane_dim = data_dim  # sparse_hyperplane_dim(tree.hyperplanes)
+        hyperplane_dim = data_dim
         hyperplanes = np.zeros((n_nodes, 2, hyperplane_dim), dtype=np.float32)
         hyperplanes[:, 0, :] = -1
 

--- a/pynndescent/rp_trees.py
+++ b/pynndescent/rp_trees.py
@@ -1157,18 +1157,17 @@ def sparse_hyperplane_dim(hyperplanes):
     return max_dim
 
 
-def convert_tree_format(tree, data_size):
-
+def convert_tree_format(tree, data_size, data_dim):
     n_nodes, n_leaves = num_nodes_and_leaves(tree)
     is_sparse = False
     if tree.hyperplanes[0].ndim == 1:
         # dense hyperplanes
-        hyperplane_dim = dense_hyperplane_dim(tree.hyperplanes)
+        hyperplane_dim = data_dim  # dense_hyperplane_dim(tree.hyperplanes)
         hyperplanes = np.zeros((n_nodes, hyperplane_dim), dtype=np.float32)
     else:
         # sparse hyperplanes
         is_sparse = True
-        hyperplane_dim = sparse_hyperplane_dim(tree.hyperplanes)
+        hyperplane_dim = data_dim  # sparse_hyperplane_dim(tree.hyperplanes)
         hyperplanes = np.zeros((n_nodes, 2, hyperplane_dim), dtype=np.float32)
         hyperplanes[:, 0, :] = -1
 

--- a/pynndescent/tests/conftest.py
+++ b/pynndescent/tests/conftest.py
@@ -61,3 +61,13 @@ def cosine_hang_data():
     this_dir = os.path.dirname(os.path.abspath(__file__))
     data_path = os.path.join(this_dir, "test_data/cosine_hang.npy")
     return np.load(data_path)
+
+
+@pytest.fixture
+def small_data():
+    return np.random.uniform(40, 5, size=(20, 5))
+
+
+@pytest.fixture
+def sparse_small_data():
+    return sparse.random(40, 5, density=0.5, format="csr")

--- a/pynndescent/tests/conftest.py
+++ b/pynndescent/tests/conftest.py
@@ -70,4 +70,6 @@ def small_data():
 
 @pytest.fixture
 def sparse_small_data():
-    return sparse.random(40, 5, density=0.5, format="csr")
+    # Too low dim might cause more than one empty row,
+    # which might decrease the computed performance
+    return sparse.random(40, 32, density=0.5, format="csr")

--- a/pynndescent/tests/test_pynndescent_.py
+++ b/pynndescent/tests/test_pynndescent_.py
@@ -563,22 +563,29 @@ def test_tree_no_split(small_data, sparse_small_data, metric):
         n_instances = data.shape[0]
         leaf_size = n_instances + 1  # just to be safe
         nnd = NNDescent(
-            data[n_instances // 2:],
-            metric=metric, n_neighbors=10, random_state=None, tree_init=True,
-            leaf_size=leaf_size
+            data[n_instances // 2 :],
+            metric=metric,
+            n_neighbors=10,
+            random_state=None,
+            tree_init=True,
+            leaf_size=leaf_size,
         )
         nnd.prepare()
 
-        knn_indices, _ = nnd.query(data[:n_instances // 2], k=10, epsilon=0.2)
+        knn_indices, _ = nnd.query(data[: n_instances // 2], k=10, epsilon=0.2)
 
-        true_nnd = NearestNeighbors(metric=metric).fit(data[n_instances // 2:])
-        true_indices = true_nnd.kneighbors(data[:n_instances // 2], 10, return_distance=False)
+        true_nnd = NearestNeighbors(metric=metric).fit(data[n_instances // 2 :])
+        true_indices = true_nnd.kneighbors(
+            data[: n_instances // 2], 10, return_distance=False
+        )
 
         num_correct = 0.0
         for i in range(true_indices.shape[0]):
             num_correct += np.sum(np.in1d(true_indices[i], knn_indices[i]))
 
         percent_correct = num_correct / (true_indices.shape[0] * 10)
-        assert percent_correct >= 0.95, (
-            "NN-descent query did not get 95% for accuracy on nearest neighbors on {} data".format(data_type)
+        assert (
+            percent_correct >= 0.95
+        ), "NN-descent query did not get 95% for accuracy on nearest neighbors on {} data".format(
+            data_type
         )

--- a/pynndescent/tests/test_pynndescent_.py
+++ b/pynndescent/tests/test_pynndescent_.py
@@ -611,7 +611,7 @@ def test_one_dimensional_data(nn_data, metric):
     nnd = NNDescent(
         nn_data[200:, :1],
         metric=metric,
-        n_neighbors=10,
+        n_neighbors=20,
         random_state=None,
         tree_init=False,
     )
@@ -637,8 +637,9 @@ def test_tree_no_split(small_data, sparse_small_data, metric):
     for data, data_type in zip([small_data, sparse_small_data], ["dense", "sparse"]):
         n_instances = data.shape[0]
         leaf_size = n_instances + 1  # just to be safe
+        data_train = data[n_instances // 2 :]
         nnd = NNDescent(
-            data[n_instances // 2 :],
+            data_train,
             metric=metric,
             n_neighbors=10,
             random_state=None,
@@ -647,11 +648,12 @@ def test_tree_no_split(small_data, sparse_small_data, metric):
         )
         nnd.prepare()
 
-        knn_indices, _ = nnd.query(data[: n_instances // 2], k=10, epsilon=0.2)
+        data_test = data[: n_instances // 2]
+        knn_indices, _ = nnd.query(data_test, k=10, epsilon=0.2)
 
-        true_nnd = NearestNeighbors(metric=metric).fit(data[n_instances // 2 :])
+        true_nnd = NearestNeighbors(metric=metric).fit(data_train)
         true_indices = true_nnd.kneighbors(
-            data[: n_instances // 2], 10, return_distance=False
+            data_test, 10, return_distance=False
         )
 
         num_correct = 0.0

--- a/pynndescent/tests/test_pynndescent_.py
+++ b/pynndescent/tests/test_pynndescent_.py
@@ -557,10 +557,16 @@ def test_tree_init_false(nn_data, metric):
     )
 
 
-@pytest.mark.parametrize("metric", ["euclidean", "manhattan"]) # cosine makes no sense for 1D
+@pytest.mark.parametrize(
+    "metric", ["euclidean", "manhattan"]
+)  # cosine makes no sense for 1D
 def test_one_dimensional_data(nn_data, metric):
     nnd = NNDescent(
-        nn_data[200:, :1], metric=metric, n_neighbors=10, random_state=None, tree_init=False
+        nn_data[200:, :1],
+        metric=metric,
+        n_neighbors=10,
+        random_state=None,
+        tree_init=False,
     )
     nnd.prepare()
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def readme():
 
 configuration = {
     "name": "pynndescent",
-    "version": "0.5.6",
+    "version": "0.5.7",
     "description": "Nearest Neighbor Descent",
     "long_description": readme(),
     "classifiers": [


### PR DESCRIPTION
The code now accepts trees with no splits (previously an exception was raised) and computes the dimension of the hyperplane directly (from `data.shape[1]`) - as discussed in #178