### PR TITLE
explicitly pass module name to namedtuple declarations

### DIFF
--- a/pynndescent/optimal_transport.py
+++ b/pynndescent/optimal_transport.py
@@ -76,6 +76,7 @@ SpanningTree = namedtuple(
         "state",  # state array
         "root",  # int
     ],
+    module=__name__,
 )
 DiGraph = namedtuple(
     "DiGraph",
@@ -90,6 +91,7 @@ DiGraph = namedtuple(
         "num_big_subsequences",  # int
         "mixing_coeff",
     ],
+    module=__name__,
 )
 NodeArcData = namedtuple(
     "NodeArcData",
@@ -101,9 +103,10 @@ NodeArcData = namedtuple(
         "source",  # unsigned int array
         "target",  # unsigned int array
     ],
+    module=__name__,
 )
 LeavingArcData = namedtuple(
-    "LeavingArcData", ["u_in", "u_out", "v_in", "delta", "change"]
+    "LeavingArcData", ["u_in", "u_out", "v_in", "delta", "change"], module=__name__
 )
 
 # Just reproduce a simpler version of numpy isclose (not numba supported yet)

--- a/pynndescent/rp_trees.py
+++ b/pynndescent/rp_trees.py
@@ -28,7 +28,7 @@ INT32_MIN = np.iinfo(np.int32).min + 1
 INT32_MAX = np.iinfo(np.int32).max - 1
 
 FlatTree = namedtuple(
-    "FlatTree", ["hyperplanes", "offsets", "children", "indices", "leaf_size"]
+    "FlatTree", ["hyperplanes", "offsets", "children", "indices", "leaf_size"], module=__name__
 )
 
 dense_hyperplane_type = numba.float32[::1]


### PR DESCRIPTION
this was suggested by @kmurphy4 on github.com/lmcinnes/umap/issues/477
as a work around to pyspark hijacking collection.namedtuple