### PR TITLE
Increase test_spearmanr tolerance

### DIFF
--- a/pynndescent/tests/test_distances.py
+++ b/pynndescent/tests/test_distances.py
@@ -309,7 +309,7 @@ def test_spearmanr():
 
     scipy_expected = stats.spearmanr(x, y)
     r = dist.spearmanr(x, y)
-    assert_array_equal(r, scipy_expected.correlation)
+    assert_array_almost_equal(r, scipy_expected.correlation)
 
 
 def test_alternative_distances():


### PR DESCRIPTION
Since the update from 0.5.2 to 0.5.7, we see the following failure on POWER architecture in Debian:
```
=================================== FAILURES ===================================
________________________________ test_spearmanr ________________________________

    def test_spearmanr():
        x = np.random.randn(100)
        y = np.random.randn(100)
    
        scipy_expected = stats.spearmanr(x, y)
        r = dist.spearmanr(x, y)
>       assert_array_equal(r, scipy_expected.correlation)
E       AssertionError: 
E       Arrays are not equal
E       
E       Mismatched elements: 1 / 1 (100%)
E       Max absolute difference: 1.38777878e-17
E       Max relative difference: 2.63709617e-16
E        x: array(0.052625)
E        y: array(0.052625)

pynndescent/tests/test_distances.py:312: AssertionError
```
Full build log:
https://buildd.debian.org/status/fetch.php?pkg=python-pynndescent&arch=ppc64el&ver=0.5.7-1&stamp=1658218015&raw=0