### PR TITLE
Make `spearmanr` a dissimilarity measure

### DIFF
--- a/pynndescent/distances.py
+++ b/pynndescent/distances.py
@@ -695,15 +695,10 @@ def rankdata(a, method="average"):
 
 @numba.njit(fastmath=True)
 def spearmanr(x, y):
-    a = np.column_stack((x, y))
+    x_rank = rankdata(x)
+    y_rank = rankdata(y)
 
-    n_vars = a.shape[1]
-
-    for i in range(n_vars):
-        a[:, i] = rankdata(a[:, i])
-    rs = np.corrcoef(a, rowvar=0)
-
-    return rs[1, 0]
+    return correlation(x_rank, y_rank)
 
 
 @numba.njit(nogil=True)

--- a/pynndescent/tests/test_distances.py
+++ b/pynndescent/tests/test_distances.py
@@ -309,7 +309,7 @@ def test_spearmanr():
 
     scipy_expected = stats.spearmanr(x, y)
     r = dist.spearmanr(x, y)
-    assert_array_almost_equal(r, scipy_expected.correlation)
+    assert_array_almost_equal(r, 1 - scipy_expected.correlation)
 
 
 def test_alternative_distances():


### PR DESCRIPTION
The `spearmanr` distance currently returns the actual Spearman rank-correlation coefficient, which behaves like a similarity measure rather than a dissimilarity measure. I believe this is not what `NNDescent` expects. Rather than using the numpy correlation matrix function, we can use the `correlation` distance after computing the rank transformation. Making this change also resolves a problem where `spearmanr` would return `nan` when both input vectors were identical.