### PR TITLE
Remove caching for functions that take distance metrics as arguments

### DIFF
--- a/pynndescent/pynndescent_.py
+++ b/pynndescent/pynndescent_.py
@@ -93,7 +93,7 @@ def generate_leaf_updates(leaf_block, dist_thresholds, data, dist):
     return updates
 
 
-@numba.njit(locals={"d": numba.float32, "p": numba.int32, "q": numba.int32}, cache=True)
+@numba.njit(locals={"d": numba.float32, "p": numba.int32, "q": numba.int32}, cache=False)
 def init_rp_tree(data, dist, current_graph, leaf_array):
 
     n_leaves = leaf_array.shape[0]
@@ -137,7 +137,7 @@ def init_rp_tree(data, dist, current_graph, leaf_array):
 @numba.njit(
     fastmath=True,
     locals={"d": numba.float32, "idx": numba.int32, "i": numba.int32},
-    cache=True,
+    cache=False,
 )
 def init_random(n_neighbors, data, heap, dist, rng_state):
     for i in range(data.shape[0]):
@@ -199,7 +199,7 @@ def generate_graph_updates(
     return updates
 
 
-@numba.njit(cache=True)
+@numba.njit(cache=False)
 def process_candidates(
     data,
     dist,

--- a/pynndescent/sparse_nndescent.py
+++ b/pynndescent/sparse_nndescent.py
@@ -53,7 +53,7 @@ def generate_leaf_updates(leaf_block, dist_thresholds, inds, indptr, data, dist)
     return updates
 
 
-@numba.njit(locals={"d": numba.float32, "p": numba.int32, "q": numba.int32}, cache=True)
+@numba.njit(locals={"d": numba.float32, "p": numba.int32, "q": numba.int32}, cache=False)
 def init_rp_tree(inds, indptr, data, dist, current_graph, leaf_array):
 
     n_leaves = leaf_array.shape[0]
@@ -99,7 +99,7 @@ def init_rp_tree(inds, indptr, data, dist, current_graph, leaf_array):
 @numba.njit(
     fastmath=True,
     locals={"d": numba.float32, "i": numba.int32, "idx": numba.int32},
-    cache=True,
+    cache=False,
 )
 def init_random(n_neighbors, inds, indptr, data, heap, dist, rng_state):
     n_samples = indptr.shape[0] - 1

--- a/pynndescent/utils.py
+++ b/pynndescent/utils.py
@@ -676,7 +676,7 @@ def apply_graph_updates_high_memory(current_graph, updates, in_graph):
     return n_changes
 
 
-@numba.njit(cache=True)
+@numba.njit(cache=False)
 def initalize_heap_from_graph_indices(heap, graph_indices, data, metric):
 
     for i in range(graph_indices.shape[0]):


### PR DESCRIPTION
There are currently a number of functions with `cache=True` that take distance metric functions as arguments. If you observe the caching behavior, every query is a cache miss and a new copy of the code is cached each time the function is run (even with the same argument types). The reason for this is that Numba is overly conservative with typing the distance function, including the actual memory address in the type. This means that the type signatures for these functions (almost) never match between different Python invocations.

You can check that the cache for these functions is missed every time by running something like

```python
import numpy as np
import pynndescent

X = np.random.randn(20, 10)
nnd = pynndescent.NNDescent(X, n_neighbors=5)

print(pynndescent.pynndescent_.process_candidates.stats)
```

There has been some discussion at the Numba project about this and related issues in https://github.com/numba/numba/issues/6772 and https://github.com/numba/numba/issues/6972. It seems that one workaround is to explicitly specify that the distance function argument is a `FunctionType` with a given signature. However, this prevents inlining of the distance function, which I expect would have significant runtime performance implications. It's possible that there is some other workaround involving producing these functions as closures when requested for a given distance metric, but that seems to also run into caching problems in some situations. Ultimately, I think it will be necessary to wait on the Numba project to resolve the problems with caching functions with inlined function arguments.

I wouldn't bother with proposing this change, except that it also seems that filling up the cache index causes significant slowdowns in compilation times. On my machine (macOS M1), in a fresh conda environment, compiling the necessary code to instantiate an `NNDescent` object tends to take around 20 seconds. As the number of cached copies of the code increases, this time slowly increases. But after sufficiently many copies (seems to be around 130), the compilation time abruptly increases to around 3 minutes. I suspect this is due to a bug somewhere in the Numba caching system, but have not been able to figure out why it is happening. In any event, since caching these functions is not currently doing any good and it seems to have detrimental effects in at least some situations, it makes sense to turn caching off.