### PR TITLE
patch: replace `np.infty` with `np.inf`

### DIFF
--- a/pynndescent/tests/test_pynndescent_.py
+++ b/pynndescent/tests/test_pynndescent_.py
@@ -25,7 +25,7 @@ def test_nn_descent_neighbor_accuracy(nn_data, seed):
 
     num_correct = 0.0
     for i in range(nn_data.shape[0]):
-        num_correct += np.sum(np.in1d(true_indices[i], knn_indices[i]))
+        num_correct += np.sum(np.isin(true_indices[i], knn_indices[i]))
 
     percent_correct = num_correct / (nn_data.shape[0] * 10)
     assert (
@@ -44,7 +44,7 @@ def test_angular_nn_descent_neighbor_accuracy(nn_data, seed):
 
     num_correct = 0.0
     for i in range(nn_data.shape[0]):
-        num_correct += np.sum(np.in1d(true_indices[i], knn_indices[i]))
+        num_correct += np.sum(np.isin(true_indices[i], knn_indices[i]))
 
     percent_correct = num_correct / (nn_data.shape[0] * 10)
     assert (
@@ -70,7 +70,7 @@ def test_bitpacked_nn_descent_neighbor_accuracy(nn_data, seed):
 
     num_correct = 0.0
     for i in range(nn_data.shape[0]):
-        num_correct += np.sum(np.in1d(true_indices[i], knn_indices[i]))
+        num_correct += np.sum(np.isin(true_indices[i], knn_indices[i]))
 
     percent_correct = num_correct / (nn_data.shape[0] * 10)
     assert (
@@ -92,7 +92,7 @@ def test_sparse_nn_descent_neighbor_accuracy(sparse_nn_data, seed):
 
     num_correct = 0.0
     for i in range(sparse_nn_data.shape[0]):
-        num_correct += np.sum(np.in1d(true_indices[i], knn_indices[i]))
+        num_correct += np.sum(np.isin(true_indices[i], knn_indices[i]))
 
     percent_correct = num_correct / (sparse_nn_data.shape[0] * 10)
     assert (
@@ -115,7 +115,7 @@ def test_sparse_angular_nn_descent_neighbor_accuracy(sparse_nn_data):
 
     num_correct = 0.0
     for i in range(sparse_nn_data.shape[0]):
-        num_correct += np.sum(np.in1d(true_indices[i], knn_indices[i]))
+        num_correct += np.sum(np.isin(true_indices[i], knn_indices[i]))
 
     percent_correct = num_correct / (sparse_nn_data.shape[0] * 10)
     assert (
@@ -132,7 +132,7 @@ def test_nn_descent_query_accuracy(nn_data):
 
     num_correct = 0.0
     for i in range(true_indices.shape[0]):
-        num_correct += np.sum(np.in1d(true_indices[i], knn_indices[i]))
+        num_correct += np.sum(np.isin(true_indices[i], knn_indices[i]))
 
     percent_correct = num_correct / (true_indices.shape[0] * 10)
     assert (
@@ -149,7 +149,7 @@ def test_nn_descent_query_accuracy_angular(nn_data):
 
     num_correct = 0.0
     for i in range(true_indices.shape[0]):
-        num_correct += np.sum(np.in1d(true_indices[i], knn_indices[i]))
+        num_correct += np.sum(np.isin(true_indices[i], knn_indices[i]))
 
     percent_correct = num_correct / (true_indices.shape[0] * 10)
     assert (
@@ -168,7 +168,7 @@ def test_sparse_nn_descent_query_accuracy(sparse_nn_data):
 
     num_correct = 0.0
     for i in range(true_indices.shape[0]):
-        num_correct += np.sum(np.in1d(true_indices[i], knn_indices[i]))
+        num_correct += np.sum(np.isin(true_indices[i], knn_indices[i]))
 
     percent_correct = num_correct / (true_indices.shape[0] * 10)
     assert (
@@ -187,7 +187,7 @@ def test_sparse_nn_descent_query_accuracy_angular(sparse_nn_data):
 
     num_correct = 0.0
     for i in range(true_indices.shape[0]):
-        num_correct += np.sum(np.in1d(true_indices[i], knn_indices[i]))
+        num_correct += np.sum(np.isin(true_indices[i], knn_indices[i]))
 
     percent_correct = num_correct / (true_indices.shape[0] * 10)
     assert (
@@ -216,7 +216,7 @@ def test_bitpacked_nn_descent_query_accuracy(nn_data):
 
     num_correct = 0.0
     for i in range(true_indices.shape[0]):
-        num_correct += np.sum(np.in1d(true_indices[i], knn_indices[i]))
+        num_correct += np.sum(np.isin(true_indices[i], knn_indices[i]))
 
     percent_correct = num_correct / (true_indices.shape[0] * 10)
     assert (
@@ -261,7 +261,7 @@ def test_random_state_none(nn_data, spatial_data):
 
     num_correct = 0.0
     for i in range(nn_data.shape[0]):
-        num_correct += np.sum(np.in1d(true_indices[i], knn_indices[i]))
+        num_correct += np.sum(np.isin(true_indices[i], knn_indices[i]))
 
     percent_correct = num_correct / (spatial_data.shape[0] * 10)
     assert (
@@ -334,7 +334,7 @@ def test_deduplicated_data_behaves_normally(seed, cosine_hang_data):
 
     num_correct = 0
     for i in range(data.shape[0]):
-        num_correct += np.sum(np.in1d(true_indices[i], knn_indices[i]))
+        num_correct += np.sum(np.isin(true_indices[i], knn_indices[i]))
 
     proportion_correct = num_correct / (data.shape[0] * n_neighbors)
     assert (
@@ -524,7 +524,7 @@ def test_update_no_prepare_query_accuracy(nn_data, metric):
 
     num_correct = 0.0
     for i in range(true_indices.shape[0]):
-        num_correct += np.sum(np.in1d(true_indices[i], knn_indices[i]))
+        num_correct += np.sum(np.isin(true_indices[i], knn_indices[i]))
 
     percent_correct = num_correct / (true_indices.shape[0] * 10)
     assert percent_correct >= 0.95, (
@@ -553,7 +553,7 @@ def test_update_w_prepare_query_accuracy(nn_data, metric):
 
     num_correct = 0.0
     for i in range(true_indices.shape[0]):
-        num_correct += np.sum(np.in1d(true_indices[i], knn_indices[i]))
+        num_correct += np.sum(np.isin(true_indices[i], knn_indices[i]))
 
     percent_correct = num_correct / (true_indices.shape[0] * 10)
     assert percent_correct >= 0.95, (
@@ -582,7 +582,7 @@ def test_update_w_prepare_query_accuracy(nn_data, metric):
 
     num_correct = 0.0
     for i in range(true_indices.shape[0]):
-        num_correct += np.sum(np.in1d(true_indices[i], knn_indices[i]))
+        num_correct += np.sum(np.isin(true_indices[i], knn_indices[i]))
 
     percent_correct = num_correct / (true_indices.shape[0] * 10)
     assert percent_correct >= 0.95, (
@@ -594,7 +594,7 @@ def evaluate_predictions(neighbors_true, neigbhors_computed, n_neighbors):
     n_correct = 0
     n_all = neighbors_true.shape[0] * n_neighbors
     for i in range(neighbors_true.shape[0]):
-        n_correct += np.sum(np.in1d(neighbors_true[i], neigbhors_computed[i]))
+        n_correct += np.sum(np.isin(neighbors_true[i], neigbhors_computed[i]))
     return n_correct / n_all
 
 
@@ -669,7 +669,7 @@ def test_tree_init_false(nn_data, metric):
 
     num_correct = 0.0
     for i in range(true_indices.shape[0]):
-        num_correct += np.sum(np.in1d(true_indices[i], knn_indices[i]))
+        num_correct += np.sum(np.isin(true_indices[i], knn_indices[i]))
 
     percent_correct = num_correct / (true_indices.shape[0] * 10)
     assert percent_correct >= 0.95, (
@@ -697,7 +697,7 @@ def test_one_dimensional_data(nn_data, metric):
 
     num_correct = 0.0
     for i in range(true_indices.shape[0]):
-        num_correct += np.sum(np.in1d(true_indices[i], knn_indices[i]))
+        num_correct += np.sum(np.isin(true_indices[i], knn_indices[i]))
 
     percent_correct = num_correct / (true_indices.shape[0] * 10)
     assert percent_correct >= 0.95, (
@@ -730,7 +730,7 @@ def test_tree_no_split(small_data, sparse_small_data, metric):
 
         num_correct = 0.0
         for i in range(true_indices.shape[0]):
-            num_correct += np.sum(np.in1d(true_indices[i], knn_indices[i]))
+            num_correct += np.sum(np.isin(true_indices[i], knn_indices[i]))
 
         percent_correct = num_correct / (true_indices.shape[0] * k)
         assert (

--- a/pynndescent/utils.py
+++ b/pynndescent/utils.py
@@ -192,7 +192,7 @@ def make_heap(n_points, size):
     heap: An ndarray suitable for passing to other numba enabled heap functions.
     """
     indices = np.full((int(n_points), int(size)), -1, dtype=np.int32)
-    distances = np.full((int(n_points), int(size)), np.infty, dtype=np.float32)
+    distances = np.full((int(n_points), int(size)), np.inf, dtype=np.float32)
     flags = np.zeros((int(n_points), int(size)), dtype=np.uint8)
     result = (indices, distances, flags)
 


### PR DESCRIPTION
# Description

Fix #241 by replacing `np.infty` with `np.inf`. Hopefully this will be enough to adopt numpy 2.0

Edit: by going through the list in [numpy 2.0 migration guide](https://numpy.org/devdocs/numpy_2_0_migration_guide.html#main-namespace), the only other verb used which will be removed in the future is `np.in1d`  (used in test), to be replaced with [`np.isin`](https://numpy.org/doc/stable/reference/generated/numpy.isin.html) which is available since numpy==1.13.0. As the min version here is 1.17, I felt free to replace it 😁