### PR TITLE
test: load pynndescent_bug_np.npz from relative path

### DIFF
--- a/pynndescent/tests/test_pynndescent_.py
+++ b/pynndescent/tests/test_pynndescent_.py
@@ -1,6 +1,7 @@
 import os
 import io
 import re
+import pathlib
 import pytest
 from contextlib import redirect_stdout
 
@@ -744,7 +745,8 @@ def test_tree_no_split(small_data, sparse_small_data, metric):
     "NUMBA_DISABLE_JIT" in os.environ, reason="Too expensive for disabled Numba"
 )
 def test_bad_data():
+    test_data_dir = pathlib.Path(__file__).parent / "test_data"
     data = np.sqrt(
-        np.load("pynndescent/tests/test_data/pynndescent_bug_np.npz")["arr_0"]
+        np.load(test_data_dir / "pynndescent_bug_np.npz")["arr_0"]
     )
     index = NNDescent(data, metric="cosine")


### PR DESCRIPTION
The test `test_bad_data` will fail to load the test data `pynndescent_bug_np.npz` in case the current directory is not the repositories root directory.

Load the `pynndescent_bug_np.npz` test data relative from the test file to not rely on the current directory.