### PR TITLE
Initial switch to uv for build pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,23 +84,18 @@ stages:
           displayName: 'Upgrade pip'
 
         - script: |
-            pip install -r requirements.txt
-          displayName: 'Install dependencies'
+            python -m pip install -U uv
+            uv sync --group cicd
+          displayName: 'Install package and dependencies'
           condition: ${{ eq(parameters.includeReleaseCandidates, false) }}
 
-        - script: |
-            pip install --pre -r requirements.txt
-          displayName: 'Install dependencies (allow pre-releases)'
-          condition: ${{ eq(parameters.includeReleaseCandidates, true) }}
+        # - script: |
+        #     pip install --pre -r requirements.txt
+        #   displayName: 'Install dependencies (allow pre-releases)'
+        #   condition: ${{ eq(parameters.includeReleaseCandidates, true) }}
 
         - script: |
-            pip install -e .
-            pip install pytest  pytest-azurepipelines
-            pip install pytest-cov
-          displayName: 'Install package'
-
-        - script: |
-            pytest pynndescent/tests --show-capture=no -v --disable-warnings --junitxml=junit/test-results.xml --cov=pynndescent/ --cov-report=xml --cov-report=html
+            uv run pytest pynndescent/tests --show-capture=no -v --disable-warnings --junitxml=junit/test-results.xml --cov=pynndescent/ --cov-report=xml --cov-report=html
           displayName: 'Run tests'
 
         - task: PublishTestResults@2
@@ -125,21 +120,17 @@ stages:
 
         - script: |
             python -m pip install --upgrade pip
-            pip install wheel
-            pip install -r requirements.txt
+            python -m pip install -U uv
+            uv sync
           displayName: 'Install dependencies'
 
-        - script: |
-            pip install -e .
-          displayName: 'Install package locally'
         
         - script: |
-            pip install build
-            python -m build --wheel --sdist --outdir dist/ .
+            uv build --no-sources --sdist --wheel
           displayName: 'Build package'
 
         - bash: |
-            export PACKAGE_VERSION="$(python setup.py --version)"
+            export PACKAGE_VERSION="$(uv version --short)"
             echo "Package Version: ${PACKAGE_VERSION}"
             echo "##vso[task.setvariable variable=packageVersionFormatted;]release-${PACKAGE_VERSION}"
           displayName: 'Get package version'
@@ -157,8 +148,8 @@ stages:
             secureFile: 'pypirc'  
 
         - script: |
-            pip install twine
-            twine upload --repository pypi --config-file $(PYPIRC_CONFIG.secureFilePath) dist/* 
+            uvx twine check dist/*
+            uvx twine upload --repository pypi --config-file $(PYPIRC_CONFIG.secureFilePath) dist/*
           displayName: 'Upload to PyPI'
           condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['packageVersionFormatted']))
 

--- a/pynndescent/tests/test_distances.py
+++ b/pynndescent/tests/test_distances.py
@@ -66,7 +66,12 @@ def test_spatial_check(spatial_data, metric):
     ],
 )
 def test_binary_check(binary_data, metric):
-    dist_matrix = pairwise_distances(binary_data, metric=metric)
+    # In never versions of scipy sokalmichener was deprecated for rogerstanimoto
+    # They should be the same in scipy's implementation
+    if metric == 'sokalmichener':
+        dist_matrix = pairwise_distances(binary_data, metric='rogerstanimoto')
+    else:
+        dist_matrix = pairwise_distances(binary_data, metric=metric)
     if metric in ("jaccard", "dice", "sokalsneath", "yule"):
         dist_matrix[np.where(~np.isfinite(dist_matrix))] = 0.0
     if metric == "russellrao":
@@ -172,9 +177,14 @@ def test_sparse_spatial_check(sparse_spatial_data, metric, decimal=6):
 )
 def test_sparse_binary_check(sparse_binary_data, metric):
     if metric in spdist.sparse_named_distances:
-        dist_matrix = pairwise_distances(
-            np.asarray(sparse_binary_data.todense()), metric=metric
-        )
+        if metric == "sokalmichener":
+            dist_matrix = pairwise_distances(
+                np.asarray(sparse_binary_data.todense()), metric="rogerstanimoto"
+            )        
+        else:
+            dist_matrix = pairwise_distances(
+                np.asarray(sparse_binary_data.todense()), metric=metric
+            )
     if metric in ("jaccard", "dice", "sokalsneath"):
         dist_matrix[np.where(~np.isfinite(dist_matrix))] = 0.0
     if metric == "russellrao":
@@ -182,6 +192,7 @@ def test_sparse_binary_check(sparse_binary_data, metric):
         # And because distance between all zero vectors should be zero
         dist_matrix[10, 11] = 0.0
         dist_matrix[11, 10] = 0.0
+    
 
     dist_function = spdist.sparse_named_distances[metric]
     if metric in spdist.sparse_need_n_features:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,9 @@ dependencies = [
     "joblib >= 0.11",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 testing = ["pytest"]
+cicd = ["pytest-azurepipelines", "pytest-cov", {include-group="testing"}]
 
 [tool.setuptools]
 packages = ["pynndescent"]


### PR DESCRIPTION
This PR has a couple of changes:

1) Using uv in the Azure DevOps pipelines
2) A fix for a couple of the tests using the sokalmichener metric which was [deprecated in scipy version 1.15.0](https://docs.scipy.org/doc/scipy-1.16.1/reference/generated/scipy.spatial.distance.sokalmichener.html). I've swapped it for rogerstanimoto (recommended by the docs)